### PR TITLE
make: Replace killall with pkill

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ test: test/test test/piggie
 	test/piggie
 	test/test dump `pidof piggie` image
 	test/test restore image
-	killall -9 piggie || :
+	pkill -9 piggie || :
 
 phaul:
 	@cd phaul; go build -v
@@ -39,7 +39,7 @@ phaul-test: test/phaul test/piggie
 	rm -rf image
 	test/piggie
 	test/phaul `pidof piggie`
-	killall -9 piggie || :
+	pkill -9 piggie || :
 
 clean:
 	@rm -f test/test test/piggie test/phaul


### PR DESCRIPTION
`killall` fails to detect the `piggie` process after restore.

```sh
$ sudo -E make
[...]
Do restore
SUCCESS!
killall -9 piggie || :
piggie: no process found

$ pidof piggie
20702 20640

$ sudo killall -9 piggie
piggie: no process found
```

Signed-off-by: Radostin Stoyanov <rstoyanov1@gmail.com>