### PR TITLE
travis updated to run against go 1.14.x and 1.13.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ sudo: required
 os:
   - linux
 go:
-  - "1.8"
-  - "1.9"
-  - "1.10"
+  - "1.14.x"
+  - "1.13.x"
+  - tip
 env:
   # Run the tests with CRIU master and criu-dev
   - CRIU_BRANCH="master"


### PR DESCRIPTION
Travis updated to run against go version 1.14.x and 1.13.x 