### PR TITLE
Support a CRIU binary outside of the default PATH

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
-sudo: required
+dist: bionic
 os:
   - linux
 go:
@@ -21,7 +21,7 @@ install:
   - cd ..
 script:
   # This builds the code without running the tests.
-  - make build phaul test/test test/phaul test/piggie
+  - make lint build phaul test/test test/phaul test/piggie
   # Run actual test as root as it uses CRIU.
   - sudo make test phaul-test
   # This builds crit-go

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ endif
 all: build test phaul phaul-test
 
 lint:
-	@golint . test phaul
+	@golint -set_exit_status . test phaul
 build:
 	@$(GO) build -v
 

--- a/main.go
+++ b/main.go
@@ -14,13 +14,22 @@ import (
 
 // Criu struct
 type Criu struct {
-	swrkCmd *exec.Cmd
-	swrkSk  *os.File
+	swrkCmd  *exec.Cmd
+	swrkSk   *os.File
+	swrkPath string
 }
 
 // MakeCriu returns the Criu object required for most operations
 func MakeCriu() *Criu {
-	return &Criu{}
+	return &Criu{
+		swrkPath: "criu",
+	}
+}
+
+// SetCriuPath allows setting the path to the CRIU binary
+// if it is in a non standard location
+func (c *Criu) SetCriuPath(path string) {
+	c.swrkPath = path
 }
 
 // Prepare sets up everything for the RPC communication to CRIU
@@ -36,7 +45,7 @@ func (c *Criu) Prepare() error {
 	defer srv.Close()
 
 	args := []string{"swrk", strconv.Itoa(fds[1])}
-	cmd := exec.Command("criu", args...)
+	cmd := exec.Command(c.swrkPath, args...)
 
 	err = cmd.Start()
 	if err != nil {


### PR DESCRIPTION
Using runc with '--criu /path/to/criu' fails with

msg="CRIU version check failed: exec: \"criu\": executable file not found in $PATH"

This adds SetCriuPath() to go-criu to allow runc to pass the location of the CRIU binary down to go-criu.