### PR TITLE
Detect if process is closed during migration in phaul using pidfd

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/checkpoint-restore/go-criu/v4
 
 go 1.13
 
-require github.com/golang/protobuf v1.4.3
+require (
+	github.com/golang/protobuf v1.4.3
+	golang.org/x/sys v0.0.0-20201204225414-ed752295db88
+)

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+golang.org/x/sys v0.0.0-20201204225414-ed752295db88 h1:KmZPnMocC93w341XZp26yTJg8Za7lhb2KhkYmixoeso=
+golang.org/x/sys v0.0.0-20201204225414-ed752295db88/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=

--- a/phaul/pidfd.go
+++ b/phaul/pidfd.go
@@ -1,0 +1,41 @@
+package phaul
+
+import (
+	"fmt"
+	"golang.org/x/sys/unix"
+)
+
+func pidfdOpen(pid int) (int32, error) {
+	r0, _, e1 := unix.Syscall(unix.SYS_PIDFD_OPEN, uintptr(pid), uintptr(0), uintptr(0))
+	pidfd := int32(r0)
+
+	if e1 != 0 {
+		return -1, e1
+	}
+
+	return pidfd, nil
+}
+
+// isPidClosed function
+// Checks that the process with the given pidfd is not closed.
+// When the process that the pidfd refers to terminates, poll
+// indicates the file descriptor as readable.
+func isPidClosed(pidfd int32) bool {
+	pollfds := []unix.PollFd{
+		{ Fd: pidfd, Events: unix.POLLIN },
+	}
+
+	for {
+		ready, err := unix.Poll(pollfds, 0)
+		if err == unix.EINTR {
+			continue // restart poll syscall
+		} else if err != nil {
+			fmt.Printf("poll failed: %v (skipping pidfd based pid reuse detection)\n", err)
+			return false
+		} else if ready == 0 {
+			return false // pidfd not readable (process still running)
+		} else {
+			return true // pidfd readable (process closed)
+		}
+	}
+}


### PR DESCRIPTION
This allows detection if a process was closed during migration reliably using ```pidfds``` if ```pidfd_open``` syscall is supported.

CRIU already detects PID reuse using task's creation time internally, this further enforces the detection through P.Haul during migration using ```pidfds```.

One short coming of this approach is that there might be a race condition between the call to ```isPidClosed()``` and ```criu.PreDump()``` which would happen if the process was closed exactly after the check and right before the pre-dump, if a process managed to reuse that pid in this duration it should be detected in CRIU using task's creation time, it is very rare but might happen.

Related issue: https://github.com/checkpoint-restore/criu/issues/717