### PR TITLE
Fix go.mod

### DIFF
--- a/crit-go/magic-gen/go.mod
+++ b/crit-go/magic-gen/go.mod
@@ -1,0 +1,5 @@
+go 1.13
+
+require github.com/thoas/go-funk v0.7.0
+
+module github.com/checkpoint-restore/go-criu/crit-go/magic-gen

--- a/crit-go/magic-gen/go.sum
+++ b/crit-go/magic-gen/go.sum
@@ -1,0 +1,8 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/thoas/go-funk v0.7.0 h1:GmirKrs6j6zJbhJIficOsz2aAI7700KsU/5YrdHRM1Y=
+github.com/thoas/go-funk v0.7.0/go.mod h1:+IWnUfUmFO1+WVYQWQtIJHeRRdaIyyYglZN7xzUPe4Q=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
 Add a separate go.mod to crit-go/magic-gen since it's a separate
binary which is not part of the library/package.

Generated by:
```
	cd crit-go/magic-gen
	touch go.mod
	go mod tidy
```