### PR TITLE
phaul: fix infinite pre-dump iterations in Migrate()

### DIFF
--- a/phaul/client.go
+++ b/phaul/client.go
@@ -101,6 +101,8 @@ func (pc *Client) Migrate() error {
 			return err
 		}
 
+		iter++
+
 		err = pc.remote.StopIter()
 		if err != nil {
 			return err


### PR DESCRIPTION
I noticed that ```iter``` was initialized to zero but never incremented in the migration loop which caused an infinite loop when migrating.

I was doing some changes to criu source relating to pre-dumps and testing my changes using ```make phaul-test``` to see how it would affect migration.

I left only this check https://github.com/checkpoint-restore/go-criu/blob/89311a427477b4de836765a76833a80616085d19/phaul/client.go#L34 in the ```isLastIter``` check just for testing purposes forcing at least ```maxIters``` iterations. That's when I discovered the problem that ```iter``` was never incremented in the migration causing an infinite number of iterations.