### PR TITLE
test/piggie.c: handle error from clone()

### DIFF
--- a/test/piggie.c
+++ b/test/piggie.c
@@ -51,6 +51,10 @@ int main(int argc, char **argv)
 	stk = mmap(NULL, STKS, PROT_READ | PROT_WRITE,
 			MAP_PRIVATE | MAP_ANON | MAP_GROWSDOWN, 0, 0);
 	pid = clone(do_test, stk + STKS, SIGCHLD | CLONE_NEWPID, argv[1]);
+	if (pid < 0) {
+		fprintf(stderr, "clone() failed: %m\n");
+		return 1;
+	}
 	printf("Child forked, pid %d\n", pid);
 
 	return 0;


### PR DESCRIPTION
When `make` is run by non-root, we get a funny test failure:

> test/piggie
> Child forked, pid -1
> test/test dump `pidof piggie` image
> CRIU version 31500
> panic: runtime error: index out of range [3] with length 3
>
> goroutine 1 [running]:
> main.main()
>         /home/kir/go/src/github.com/checkpoint-restore/go-criu/test/main.go:80 +0xd0f
> make: *** [Makefile:28: test] Error 2

After this commit it's a bit more clear/correct:

> test/piggie
> clone() failed: Operation not permitted
> make: *** [Makefile:27: test] Error 1

Signed-off-by: Kir Kolyshkin <kolyshkin@gmail.com>