### PR TITLE
gha: add go 1.16-rc1, rm 1.13.x

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.13.x, 1.14.x, 1.15.x]
+        go-version: [1.14.x, 1.15.x, 1.16.0-rc1]
         criu_branch: [master, criu-dev]
 
     steps:
@@ -27,6 +27,7 @@ jobs:
     - name: install go ${{ matrix.go-version }}
       uses: actions/setup-go@v2
       with:
+        stable: '!contains(${{ matrix.go-version }}, "beta") && !contains(${{ matrix.go-version }}, "rc")'
         go-version: ${{ matrix.go-version }}
 
     - name: Run tests


### PR DESCRIPTION
Go 1.13.x is not supported since go 1.15 was released in August 2020.

Go 1.16 will be released this month, it makes sense to try it now.