### PR TITLE
ci/gha: bump go 1.16-rc1 -> 1.16.x

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.14.x, 1.15.x, 1.16.0-rc1]
+        go-version: [1.14.x, 1.15.x, 1.16.x]
         criu_branch: [master, criu-dev]
 
     steps:


### PR DESCRIPTION
As the final go 1.16 is released, rc1 is no longer available.

This fixes our CI.