### PR TITLE
README: prepare for v5.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,12 @@ As go-criu is imported in other projects and as Go modules are expected
 to follow Semantic Versioning go-criu will also follow Semantic Versioning
 starting with the 4.0.0 release.
 
-4.0.0 is based on CRIU 3.14
+The following table shows the relation between go-criu and criu versions:
+
+| Major version  | Latest release | CRIU version |
+| -------------- | -------------- | ------------ |
+| v5             | 5.0.0          | 3.15         |
+| v4             | 4.1.0          | 3.14         |
 
 ## How to contribute
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 [![test](https://github.com/checkpoint-restore/go-criu/workflows/ci/badge.svg?branch=master)](https://github.com/checkpoint-restore/go-criu/actions?query=workflow%3Aci)
 [![verify](https://github.com/checkpoint-restore/go-criu/workflows/verify/badge.svg?branch=master)](https://github.com/checkpoint-restore/go-criu/actions?query=workflow%3Averify)
 
-## go-criu -- Go bindings for [CRIU](https://criu.org/)
+## go-criu -- Go bindings for CRIU
 
-This repository provides Go bindings for CRIU. The code is based on the Go based PHaul
+This repository provides Go bindings for [CRIU](https://criu.org/). The code is based on the Go-based PHaul
 implementation from the CRIU repository. For easier inclusion into other Go projects the
 CRIU Go bindings have been moved to this repository.
 
@@ -11,13 +11,13 @@ The Go bindings provide an easy way to use the CRIU RPC calls from Go without th
 to set up all the infrastructure to make the actual RPC connection to CRIU.
 
 The following example would print the version of CRIU:
-```
+```go
 	c := criu.MakeCriu()
 	version, err := c.GetCriuVersion()
 	fmt.Println(version)
 ```
 or to just check if at least a certain CRIU version is installed:
-```
+```go
 	c := criu.MakeCriu()
 	result, err := c.IsCriuAtLeast(31100)
 ```

--- a/README.md
+++ b/README.md
@@ -12,11 +12,24 @@ to set up all the infrastructure to make the actual RPC connection to CRIU.
 
 The following example would print the version of CRIU:
 ```go
+import (
+	"log"
+
+	"github.com/checkpoint/restore/go-criu/v5"
+)
+
+func main() {
 	c := criu.MakeCriu()
 	version, err := c.GetCriuVersion()
-	fmt.Println(version)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	log.Println(version)
+}
 ```
+
 or to just check if at least a certain CRIU version is installed:
+
 ```go
 	c := criu.MakeCriu()
 	result, err := c.IsCriuAtLeast(31100)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![test](https://github.com/checkpoint-restore/go-criu/workflows/ci/badge.svg?branch=master)](https://github.com/checkpoint-restore/go-criu/actions?query=workflow%3Aci)
 [![verify](https://github.com/checkpoint-restore/go-criu/workflows/verify/badge.svg?branch=master)](https://github.com/checkpoint-restore/go-criu/actions?query=workflow%3Averify)
+[![Go Reference](https://pkg.go.dev/badge/github.com/checkpoint-restore/go-criu.svg)](https://pkg.go.dev/github.com/checkpoint-restore/go-criu)
 
 ## go-criu -- Go bindings for CRIU
 


### PR DESCRIPTION
In anticipation of v5.0.0 release, add some info to README (and fix some nits while at it).

 - README: no links in header, highlight go code
 - README: provide a complete example that includes import statement
 - README: add info about v5, use a table
 - README: add link to go doc