### PR TITLE
CI nits and updates

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
 
     - name: checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: install criu
       if: matrix.criu_branch == ''

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.15.x, 1.16.x, 1.17.x]
+        go-version: [1.17.x, 1.18.x]
         criu_branch: ["", criu-dev]
 
     steps:
@@ -48,7 +48,7 @@ jobs:
         sudo make -C crit-go/magic-gen build magicgen test
 
     - name: Check code coverage
-      if: matrix.go-version == '1.17.x' && matrix.criu_branch == 'criu-dev'
+      if: matrix.go-version == '1.18.x' && matrix.criu_branch == 'criu-dev'
       run: |
         # Run actual test as root as it uses CRIU.
         sudo make coverage

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         go-version: [1.15.x, 1.16.x, 1.17.x]
-        criu_branch: [master, criu-dev]
+        criu_branch: ["", criu-dev]
 
     steps:
 
@@ -17,6 +17,17 @@ jobs:
       uses: actions/checkout@v2
 
     - name: install criu
+      if: matrix.criu_branch == ''
+      env:
+        REPO: https://download.opensuse.org/repositories/devel:/tools:/criu/xUbuntu_20.04
+      run: |
+        curl -fSsl $REPO/Release.key | sudo apt-key add -
+        echo "deb $REPO/ /" | sudo tee /etc/apt/sources.list.d/criu.list
+        sudo apt update
+        sudo apt install criu
+
+    - name: build criu ${{ matrix.criu_branch }}
+      if: matrix.criu_branch != ''
       run: |
         sudo apt-get install -y libprotobuf-dev libprotobuf-c-dev protobuf-c-compiler protobuf-compiler python-protobuf libnl-3-dev libnet-dev libcap-dev
         git clone --depth=1 --single-branch -b ${{ matrix.criu_branch }} https://github.com/checkpoint-restore/criu.git

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -5,7 +5,7 @@ jobs:
   lint:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: golangci/golangci-lint-action@v2
       with:
         # must be specified without patch version
@@ -16,7 +16,7 @@ jobs:
   gomod:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: verify go.mod/go.sum
       run: |
         go mod tidy

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -6,10 +6,12 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
+    - uses: actions/setup-go@v2
+      with:
+        go-version: 1.18.x
     - uses: golangci/golangci-lint-action@v2
       with:
-        # must be specified without patch version
-        version: v1.42
+        version: v1.45
         # Only show new issues for a pull request.
         only-new-issues: true
 


### PR DESCRIPTION
* Instead of compiling criu from master branch, use a binary package.
* Bump actions/checkout to v3.
* Remove unsupported Go versions, add 1.18.x.
* Bump golangci-lint to v1.45

See individual commits for details.