### PR TITLE
Add makefile for testing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Run tests
       run: |
         # Run actual test as root as it uses CRIU.
-        sudo make test phaul-test
+        sudo make test
         # Test magicgen script
         make -C scripts test
 

--- a/Makefile
+++ b/Makefile
@@ -1,86 +1,24 @@
 SHELL = /bin/bash
 GO ?= go
 CC ?= gcc
-COVERAGE_PATH ?= $(shell pwd)/.coverage
-CRIU_FEATURE_MEM_TRACK = $(shell if criu check --feature mem_dirty_track > /dev/null; then echo 1; else echo 0; fi)
-CRIU_FEATURE_LAZY_PAGES = $(shell if criu check --feature uffd-noncoop > /dev/null; then echo 1; else echo 0; fi)
-CRIU_FEATURE_PIDFD_STORE = $(shell if criu check --feature pidfd_store > /dev/null; then echo 1; else echo 0; fi)
 
-export CRIU_FEATURE_MEM_TRACK CRIU_FEATURE_LAZY_PAGES CRIU_FEATURE_PIDFD_STORE
-
-all: build test phaul-test
+all: build
 
 lint:
 	golangci-lint run ./...
 
 build:
+	$(MAKE) -C scripts
 	$(GO) build -v ./...
 
-TEST_PAYLOAD := test/piggie/piggie
-TEST_BINARIES := test/test $(TEST_PAYLOAD) test/phaul/phaul
-COVERAGE_BINARIES := test/test.coverage test/phaul/phaul.coverage
-test-bin: $(TEST_BINARIES)
+test: build
+	$(MAKE) -C test
 
-test/piggie/piggie: test/piggie/piggie.c
-	$(CC) $^ -o $@
+coverage:
+	$(MAKE) -C test coverage
 
-test/test: test/main.go
-	$(GO) build -v -o $@ $^
-
-test: $(TEST_BINARIES)
-	mkdir -p image
-	PID=$$(test/piggie/piggie) && { \
-	test/test dump $$PID image && \
-	test/test restore image; \
-	pkill -9 piggie; \
-	}
-	rm -rf image
-
-test/phaul/phaul: test/phaul/main.go
-	$(GO) build -v -o $@ $^
-
-phaul-test: $(TEST_BINARIES)
-	rm -rf image
-	PID=$$(test/piggie/piggie) && { \
-	test/phaul/phaul $$PID; \
-	pkill -9 piggie; \
-	}
-
-test/test.coverage: test/*.go
-	$(GO) test \
-		-covermode=count \
-		-coverpkg=./... \
-		-mod=vendor \
-		-tags coverage \
-		-buildmode=pie -c -o $@ $^
-
-test/phaul/phaul.coverage: test/phaul/*.go
-	$(GO) test \
-		-covermode=count \
-		-coverpkg=./... \
-		-mod=vendor \
-		-tags coverage \
-		-buildmode=pie -c -o $@ $^
-
-coverage: $(COVERAGE_BINARIES) $(TEST_PAYLOAD)
-	mkdir -p $(COVERAGE_PATH)
-	mkdir -p image
-	PID=$$(test/piggie/piggie) && { \
-	test/test.coverage -test.coverprofile=coverprofile.integration.$$RANDOM -test.outputdir=${COVERAGE_PATH} COVERAGE dump $$PID image && \
-	test/test.coverage -test.coverprofile=coverprofile.integration.$$RANDOM -test.outputdir=${COVERAGE_PATH} COVERAGE restore image; \
-	pkill -9 piggie; \
-	}
-	rm -rf image
-	PID=$$(test/piggie/piggie) && { \
-	test/phaul/phaul.coverage -test.coverprofile=coverprofile.integration.$$RANDOM -test.outputdir=${COVERAGE_PATH} COVERAGE $$PID; \
-	pkill -9 piggie; \
-	}
-	echo "mode: set" > .coverage/coverage.out && cat .coverage/coverprofile* | \
-		grep -v mode: | sort -r | awk '{if($$1 != last) {print $$0;last=$$1}}' >> .coverage/coverage.out
-
-clean:
-	@rm -f $(TEST_BINARIES) $(COVERAGE_BINARIES) codecov
-	@rm -rf image $(COVERAGE_PATH)
+codecov:
+	$(MAKE) -C test codecov
 
 rpc/rpc.proto:
 	curl -sSL https://raw.githubusercontent.com/checkpoint-restore/criu/master/images/rpc.proto -o $@
@@ -99,9 +37,4 @@ vendor:
 	GO111MODULE=on $(GO) mod vendor
 	GO111MODULE=on $(GO) mod verify
 
-codecov:
-	curl -Os https://uploader.codecov.io/latest/linux/codecov
-	chmod +x codecov
-	./codecov -f '.coverage/coverage.out'
-
-.PHONY: build test phaul-test test-bin clean lint vendor coverage codecov
+.PHONY: build test lint vendor coverage codecov

--- a/test/Makefile
+++ b/test/Makefile
@@ -71,7 +71,7 @@ coverage: $(COVERAGE_BINARIES) $(TEST_PAYLOAD)
 		grep -v mode: | sort -r | awk '{if($$1 != last) {print $$0;last=$$1}}' >> .coverage/coverage.out
 
 codecov:
-	curl -Os https://uploader.codecov.io/lalinux/codecov
+	curl -Os https://uploader.codecov.io/latest/linux/codecov
 	chmod +x codecov
 	./codecov -f '.coverage/coverage.out'
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,0 +1,82 @@
+SHELL = /bin/bash
+GO ?= go
+CC ?= gcc
+COVERAGE_PATH ?= $(shell pwd)/.coverage
+CRIU_FEATURE_MEM_TRACK = $(shell if criu check --feature mem_dirty_track > /dev/null; then echo 1; else echo 0; fi)
+CRIU_FEATURE_LAZY_PAGES = $(shell if criu check --feature uffd-noncoop > /dev/null; then echo 1; else echo 0; fi)
+CRIU_FEATURE_PIDFD_STORE = $(shell if criu check --feature pidfd_store > /dev/null; then echo 1; else echo 0; fi)
+
+export CRIU_FEATURE_MEM_TRACK CRIU_FEATURE_LAZY_PAGES CRIU_FEATURE_PIDFD_STORE
+
+TEST_PAYLOAD := piggie/piggie
+TEST_BINARIES := test $(TEST_PAYLOAD) phaul/phaul
+COVERAGE_BINARIES := test.coverage phaul/phaul.coverage
+test-bin: $(TEST_BINARIES)
+
+all: $(TEST_BINARIES) phaul-test
+	mkdir -p image
+	PID=$$(piggie/piggie) && { \
+	test dump $$PID image && \
+	test restore image; \
+	pkill -9 piggie; \
+	}
+	rm -rf image
+
+piggie/piggie: piggie/piggie.c
+	$(CC) $^ -o $@
+
+test: main.go
+	$(GO) build -v -o $@ $^
+
+phaul/phaul: phaul/main.go
+	$(GO) build -v -o $@ $^
+
+phaul-test: $(TEST_BINARIES)
+	rm -rf image
+	PID=$$(piggie/piggie) && { \
+	phaul/phaul $$PID; \
+	pkill -9 piggie; \
+	}
+
+test.coverage: *.go
+	$(GO) test \
+		-covermode=count \
+		-coverpkg=./... \
+		-mod=vendor \
+		-tags coverage \
+		-buildmode=pie -c -o $@ $^
+
+phaul/phaul.coverage: phaul/*.go
+	$(GO) test \
+		-covermode=count \
+		-coverpkg=./... \
+		-mod=vendor \
+		-tags coverage \
+		-buildmode=pie -c -o $@ $^
+
+coverage: $(COVERAGE_BINARIES) $(TEST_PAYLOAD)
+	mkdir -p $(COVERAGE_PATH)
+	mkdir -p image
+	PID=$$(piggie/piggie) && { \
+	test.coverage -test.coverprofile=coverprofile.integration.$$RANDOM -test.outputdir=${COVERAGE_PATH} COVERAGE dump $$PID image && \
+	test.coverage -test.coverprofile=coverprofile.integration.$$RANDOM -test.outputdir=${COVERAGE_PATH} COVERAGE restore image; \
+	pkill -9 piggie; \
+	}
+	rm -rf image
+	PID=$$(piggie/piggie) && { \
+	phaul/phaul.coverage -test.coverprofile=coverprofile.integration.$$RANDOM -test.outputdir=${COVERAGE_PATH} COVERAGE $$PID; \
+	pkill -9 piggie; \
+	}
+	echo "mode: set" > .coverage/coverage.out && cat .coverage/coverprofile* | \
+		grep -v mode: | sort -r | awk '{if($$1 != last) {print $$0;last=$$1}}' >> .coverage/coverage.out
+
+codecov:
+	curl -Os https://uploader.codecov.io/lalinux/codecov
+	chmod +x codecov
+	./codecov -f '.coverage/coverage.out'
+
+clean:
+	@rm -f $(TEST_BINARIES) $(COVERAGE_BINARIES) codecov
+	@rm -rf image $(COVERAGE_PATH)
+
+.PHONY: all clean coverage codecov phaul-test test-bin


### PR DESCRIPTION
Running tests with CRIU requires root privileges, however, building go binaries does not. This patch separates the build steps from the steps used to run tests. This allows to build applications such as crit using `make` without root privileges.