### PR TITLE
test: drop test-bin target

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,16 +30,15 @@ jobs:
         go-version: ${{ matrix.go-version }}
 
     - name: Run tests
-      run: |
-        # Run actual test as root as it uses CRIU.
-        sudo make test
-        # Test magicgen script
-        make -C scripts test
+      run: sudo env "PATH=$PATH" make test
+
+    - name: Test magicgen script
+      run: make -C scripts test
 
     - name: Check code coverage
       if: matrix.go-version == '1.17.x' && matrix.criu_branch == 'criu-dev'
       run: |
         # Run actual test as root as it uses CRIU.
-        sudo make coverage
+        sudo env "PATH=$PATH" make coverage
         # Upload coverage results to codecov
         sudo -E make codecov

--- a/test/Makefile
+++ b/test/Makefile
@@ -11,7 +11,6 @@ export CRIU_FEATURE_MEM_TRACK CRIU_FEATURE_LAZY_PAGES CRIU_FEATURE_PIDFD_STORE
 TEST_PAYLOAD := piggie/piggie
 TEST_BINARIES := test $(TEST_PAYLOAD) phaul/phaul
 COVERAGE_BINARIES := test.coverage phaul/phaul.coverage
-test-bin: $(TEST_BINARIES)
 
 all: $(TEST_BINARIES) phaul-test
 	mkdir -p image
@@ -79,4 +78,4 @@ clean:
 	@rm -f $(TEST_BINARIES) $(COVERAGE_BINARIES) codecov
 	@rm -rf image $(COVERAGE_PATH)
 
-.PHONY: all clean coverage codecov phaul-test test-bin
+.PHONY: all clean coverage codecov phaul-test


### PR DESCRIPTION
The current [default target](https://www.gnu.org/software/make/manual/html_node/Rules.html) in test/Makefile is `test-bin` as this is the first target in the makefile. This was unintentional change introduced in https://github.com/checkpoint-restore/go-criu/pull/71. The default target should be `all`. However, `test-bin` does not appear to be used anywhere and thus, we can remove it.
