### PR TITLE
test: fix running test.coverage command

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -57,8 +57,8 @@ coverage: $(COVERAGE_BINARIES) $(TEST_PAYLOAD)
 	mkdir -p $(COVERAGE_PATH)
 	mkdir -p image
 	PID=$$(piggie/piggie) && { \
-	test.coverage -test.coverprofile=coverprofile.integration.$$RANDOM -test.outputdir=${COVERAGE_PATH} COVERAGE dump $$PID image && \
-	test.coverage -test.coverprofile=coverprofile.integration.$$RANDOM -test.outputdir=${COVERAGE_PATH} COVERAGE restore image; \
+	./test.coverage -test.coverprofile=coverprofile.integration.$$RANDOM -test.outputdir=${COVERAGE_PATH} COVERAGE dump $$PID image && \
+	./test.coverage -test.coverprofile=coverprofile.integration.$$RANDOM -test.outputdir=${COVERAGE_PATH} COVERAGE restore image; \
 	pkill -9 piggie; \
 	}
 	rm -rf image


### PR DESCRIPTION
In commit 958702777582dab243bf68e949e49218ee1b1aff the `test.coverage` command was moved into a Makefile located in the `test/` subdirectory.