### PR TITLE
ci: enable tests with go 1.19.x

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.17.x, 1.18.x]
+        go-version: [1.17.x, 1.18.x, 1.19.x]
         # criu is pre-installed in the Ubuntu 20.04 GitHub Action virtual
         # environment as a dependency for Podman
         criu_branch: ["", criu-dev]

--- a/phaul/api.go
+++ b/phaul/api.go
@@ -27,19 +27,19 @@ type Remote interface {
 // Local interface
 // Interface to local classes. Client calls them when it needs something on the source node.
 //
-//Methods:
+// Methods:
 //
-// - DumpCopyRestore() is called on client side when the
-//   pre-iterations are over and it's time to do full dump,
-//   copy images and restore them on the server side.
-//   All the time this method is executed victim tree is
-//   frozen on client. Returning nil kills the tree, error
-//   unfreezes it and resumes. The criu argument is the
-//   pointer on created criu.Criu object on which client
-//   may call Dump(). The requirement on opts passed are:
-//          set Ps.Fd to comm.Memfd
-//          set ParentImg to lastClientImagesPath
-//          set TrackMem to true
+//   - DumpCopyRestore() is called on client side when the
+//     pre-iterations are over and it's time to do full dump,
+//     copy images and restore them on the server side.
+//     All the time this method is executed victim tree is
+//     frozen on client. Returning nil kills the tree, error
+//     unfreezes it and resumes. The criu argument is the
+//     pointer on created criu.Criu object on which client
+//     may call Dump(). The requirement on opts passed are:
+//     set Ps.Fd to comm.Memfd
+//     set ParentImg to lastClientImagesPath
+//     set TrackMem to true
 type Local interface {
 	DumpCopyRestore(criu *criu.Criu, c Config, lastClientImagesPath string) error
 }

--- a/phaul/server.go
+++ b/phaul/server.go
@@ -34,7 +34,6 @@ func MakePhaulServer(c Config) (*Server, error) {
 	return &Server{imgs: img, cfg: c, cr: cr}, nil
 }
 
-//
 // StartIter phaul.Remote methods
 func (s *Server) StartIter() error {
 	fmt.Printf("S: start iter\n")

--- a/rpc/rpc.pb.go
+++ b/rpc/rpc.pb.go
@@ -1331,7 +1331,6 @@ func (x *CriuNotify) GetPid() int32 {
 	return 0
 }
 
-//
 // List of features which can queried via
 // CRIU_REQ_TYPE__FEATURE_CHECK
 type CriuFeatures struct {

--- a/test/main_coverage_test.go
+++ b/test/main_coverage_test.go
@@ -1,3 +1,4 @@
+//go:build coverage
 // +build coverage
 
 package main


### PR DESCRIPTION
The verify / lint CI workflow running `golangci-lint` currently fails with:
```
phaul/api.go:30: File is not `gofmt`-ed with `-s` (gofmt)
//Methods:
phaul/server.go:37: File is not `gofmt`-ed with `-s` (gofmt)
//
```
This problem has been reported in https://github.com/golangci/golangci-lint-action/issues/535

The problem occurs because, for some reason, golangci-lint is using `gofmt` from go 1.19. This pull request formats the code using gofmt and enables the CI tests to run with go 1.19.