### PR TITLE
chore: bump Go version to 1.16

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/checkpoint-restore/go-criu/v5
 
-go 1.13
+go 1.16
 
 require (
 	github.com/spf13/cobra v1.4.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,13 +1,16 @@
 # github.com/inconshreveable/mousetrap v1.0.0
 github.com/inconshreveable/mousetrap
 # github.com/spf13/cobra v1.4.0
+## explicit
 github.com/spf13/cobra
 # github.com/spf13/pflag v1.0.5
 github.com/spf13/pflag
 # golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c
+## explicit
 golang.org/x/sys/internal/unsafeheader
 golang.org/x/sys/unix
 # google.golang.org/protobuf v1.28.0
+## explicit
 google.golang.org/protobuf/encoding/protojson
 google.golang.org/protobuf/encoding/prototext
 google.golang.org/protobuf/encoding/protowire


### PR DESCRIPTION
1.16 ensures that we retain compatibility with Podman.