### PR TITLE
Add functions for stats

### DIFF
--- a/crit/explore.go
+++ b/crit/explore.go
@@ -2,6 +2,7 @@ package crit
 
 import (
 	"fmt"
+	"path/filepath"
 	"strconv"
 
 	"github.com/checkpoint-restore/go-criu/v6/crit/images"
@@ -20,7 +21,7 @@ type PsTree struct {
 
 // ExplorePs constructs the process tree and returns the root process
 func (c *crit) ExplorePs() (*PsTree, error) {
-	psTreeImg, err := getImg(fmt.Sprintf("%s/pstree.img", c.inputDirPath))
+	psTreeImg, err := getImg(filepath.Join(c.inputDirPath, "pstree.img"))
 	if err != nil {
 		return nil, err
 	}
@@ -31,7 +32,7 @@ func (c *crit) ExplorePs() (*PsTree, error) {
 		process := entry.Message.(*images.PstreeEntry)
 		pId := process.GetPid()
 
-		coreImg, err := getImg(fmt.Sprintf("%s/core-%d.img", c.inputDirPath, pId))
+		coreImg, err := getImg(filepath.Join(c.inputDirPath, fmt.Sprintf("core-%d.img", pId)))
 		if err != nil {
 			return nil, err
 		}
@@ -77,7 +78,7 @@ type File struct {
 // ExploreFds searches the process tree for open files
 // and returns a list of PIDs with the corresponding files
 func (c *crit) ExploreFds() ([]*Fd, error) {
-	psTreeImg, err := getImg(fmt.Sprintf("%s/pstree.img", c.inputDirPath))
+	psTreeImg, err := getImg(filepath.Join(c.inputDirPath, "pstree.img"))
 	if err != nil {
 		return nil, err
 	}
@@ -87,13 +88,13 @@ func (c *crit) ExploreFds() ([]*Fd, error) {
 		process := entry.Message.(*images.PstreeEntry)
 		pId := process.GetPid()
 		// Get file with object IDs
-		idsImg, err := getImg(fmt.Sprintf("%s/ids-%d.img", c.inputDirPath, pId))
+		idsImg, err := getImg(filepath.Join(c.inputDirPath, fmt.Sprintf("ids-%d.img", pId)))
 		if err != nil {
 			return nil, err
 		}
 		filesId := idsImg.Entries[0].Message.(*images.TaskKobjIdsEntry).GetFilesId()
 		// Get open file descriptors
-		fdInfoImg, err := getImg(fmt.Sprintf("%s/fdinfo-%d.img", c.inputDirPath, filesId))
+		fdInfoImg, err := getImg(filepath.Join(c.inputDirPath, fmt.Sprintf("fdinfo-%d.img", filesId)))
 		if err != nil {
 			return nil, err
 		}
@@ -113,7 +114,7 @@ func (c *crit) ExploreFds() ([]*Fd, error) {
 			fdEntry.Files = append(fdEntry.Files, &file)
 		}
 		// Get chroot and chdir info
-		fsImg, err := getImg(fmt.Sprintf("%s/fs-%d.img", c.inputDirPath, pId))
+		fsImg, err := getImg(filepath.Join(c.inputDirPath, fmt.Sprintf("fs-%d.img", pId)))
 		if err != nil {
 			return nil, err
 		}
@@ -161,7 +162,7 @@ type Mem struct {
 // ExploreMems traverses the process tree and returns a
 // list of processes with the corresponding memory mapping
 func (c *crit) ExploreMems() ([]*MemMap, error) {
-	psTreeImg, err := getImg(fmt.Sprintf("%s/pstree.img", c.inputDirPath))
+	psTreeImg, err := getImg(filepath.Join(c.inputDirPath, "pstree.img"))
 	if err != nil {
 		return nil, err
 	}
@@ -181,7 +182,7 @@ func (c *crit) ExploreMems() ([]*MemMap, error) {
 		process := entry.Message.(*images.PstreeEntry)
 		pId := process.GetPid()
 		// Get memory mappings
-		mmImg, err := getImg(fmt.Sprintf("%s/mm-%d.img", c.inputDirPath, pId))
+		mmImg, err := getImg(filepath.Join(c.inputDirPath, fmt.Sprintf("mm-%d.img", pId)))
 		if err != nil {
 			return nil, err
 		}
@@ -288,7 +289,7 @@ type Vma struct {
 // ExploreRss traverses the process tree and returns
 // a list of processes with their RSS mappings
 func (c *crit) ExploreRss() ([]*RssMap, error) {
-	psTreeImg, err := getImg(fmt.Sprintf("%s/pstree.img", c.inputDirPath))
+	psTreeImg, err := getImg(filepath.Join(c.inputDirPath, "pstree.img"))
 	if err != nil {
 		return nil, err
 	}
@@ -298,13 +299,13 @@ func (c *crit) ExploreRss() ([]*RssMap, error) {
 		process := entry.Message.(*images.PstreeEntry)
 		pId := process.GetPid()
 		// Get virtual memory addresses
-		mmImg, err := getImg(fmt.Sprintf("%s/mm-%d.img", c.inputDirPath, pId))
+		mmImg, err := getImg(filepath.Join(c.inputDirPath, fmt.Sprintf("mm-%d.img", pId)))
 		if err != nil {
 			return nil, err
 		}
 		vmas := mmImg.Entries[0].Message.(*images.MmEntry).GetVmas()
 		// Get physical memory addresses
-		pagemapImg, err := getImg(fmt.Sprintf("%s/pagemap-%d.img", c.inputDirPath, pId))
+		pagemapImg, err := getImg(filepath.Join(c.inputDirPath, fmt.Sprintf("pagemap-%d.img", pId)))
 		if err != nil {
 			return nil, err
 		}

--- a/crit/stats.go
+++ b/crit/stats.go
@@ -1,0 +1,46 @@
+package crit
+
+import (
+	"errors"
+	"path/filepath"
+
+	"github.com/checkpoint-restore/go-criu/v6/crit/images"
+)
+
+// Helper function to load stats file into Go struct
+func getStats(path string) (*images.StatsEntry, error) {
+	c := New(path, "", "", false, false)
+	statsImg, err := c.Decode()
+	if err != nil {
+		return nil, err
+	}
+
+	stats, ok := statsImg.Entries[0].Message.(*images.StatsEntry)
+	if !ok {
+		return nil, errors.New("Failed to type assert stats image")
+	}
+
+	return stats, nil
+}
+
+// GetDumpStats returns the dump statistics of a checkpoint.
+// dir is the path to the directory with the checkpoint images.
+func GetDumpStats(dir string) (*images.DumpStatsEntry, error) {
+	stats, err := getStats(filepath.Join(dir, "stats-dump"))
+	if err != nil {
+		return nil, err
+	}
+
+	return stats.GetDump(), nil
+}
+
+// GetRestoreStats returns the restore statistics of a checkpoint.
+// dir is the path to the directory with the checkpoint images.
+func GetRestoreStats(dir string) (*images.RestoreStatsEntry, error) {
+	stats, err := getStats(filepath.Join(dir, "stats-restore"))
+	if err != nil {
+		return nil, err
+	}
+
+	return stats.GetRestore(), nil
+}

--- a/crit/utils.go
+++ b/crit/utils.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strconv"
 
 	"github.com/checkpoint-restore/go-criu/v6/crit/images"
@@ -112,7 +113,7 @@ func getFilePath(dir string, fId uint32, fType images.FdTypes) (string, error) {
 	var err error
 	// Get open files
 	if filesImg == nil {
-		filesImg, err = getImg(fmt.Sprintf("%s/files.img", dir))
+		filesImg, err = getImg(filepath.Join(dir, "files.img"))
 		if err != nil {
 			return "", err
 		}
@@ -152,7 +153,7 @@ func getRegFilePath(dir string, file *images.FileEntry, fId uint32) (string, err
 	}
 
 	if regImg == nil {
-		regImg, err = getImg(fmt.Sprintf("%s/reg-files.img", dir))
+		regImg, err = getImg(filepath.Join(dir, "reg-files.img"))
 		if err != nil {
 			return "", err
 		}
@@ -178,7 +179,7 @@ func getPipeFilePath(dir string, file *images.FileEntry, fId uint32) (string, er
 	}
 
 	if pipeImg == nil {
-		pipeImg, err = getImg(fmt.Sprintf("%s/pipes.img", dir))
+		pipeImg, err = getImg(filepath.Join(dir, "pipes.img"))
 		if err != nil {
 			return "", err
 		}
@@ -209,7 +210,7 @@ func getUnixSkFilePath(dir string, file *images.FileEntry, fId uint32) (string, 
 	}
 
 	if unixSkImg == nil {
-		unixSkImg, err = getImg(fmt.Sprintf("%s/unixsk.img", dir))
+		unixSkImg, err = getImg(filepath.Join(dir, "unixsk.img"))
 		if err != nil {
 			return "", err
 		}

--- a/test/crit/Makefile
+++ b/test/crit/Makefile
@@ -2,7 +2,10 @@ CC ?= gcc
 GO ?= go
 CRIU ?= criu
 
-all: integration-test e2e-test clean
+all: unit-test integration-test e2e-test clean
+
+unit-test: test-imgs
+	go test -v ./...
 
 integration-test: test-imgs crit-test
 	@echo "Running integration test"
@@ -16,6 +19,8 @@ test-imgs: ../loop/loop
 	$(eval PID := $(shell ../loop/loop))
 	mkdir -p $@
 	$(CRIU) dump -v4 -o dump.log -D $@ -t $(PID)
+	$(CRIU) restore -v4 -o restore.log -D $@ -d
+	pkill -9 loop
 
 ../../crit/bin/crit:
 	$(MAKE) -C ../../crit bin/crit
@@ -29,4 +34,4 @@ crit-test: main.go
 clean:
 	@rm -rf test-imgs
 
-.PHONY: all test integration-test e2e-test clean
+.PHONY: all test unit-test integration-test e2e-test clean

--- a/test/crit/stats_test.go
+++ b/test/crit/stats_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/checkpoint-restore/go-criu/v6/crit"
+)
+
+func TestGetDumpStats(t *testing.T) {
+	dumpStats, err := crit.GetDumpStats("test-imgs")
+	if err != nil {
+		t.Error("Failed to get stats")
+	}
+	if dumpStats.GetPagesWritten() == 0 {
+		t.Error("PagesWritten is 0")
+	}
+}
+
+func TestGetRestoreStats(t *testing.T) {
+	restoreStats, err := crit.GetRestoreStats("test-imgs")
+	if err != nil {
+		t.Error("Failed to get stats")
+	}
+	if restoreStats.GetForkingTime() == 0 {
+		t.Error("ForkingTime is 0")
+	}
+}


### PR DESCRIPTION
This also fixes some of the places where `fmt.Sprintf` was being used instead of `filepath.Join`