### PR TITLE
ci: disable musttag in golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,6 +4,8 @@ linters:
     - performance
     - unused
     - format
+  disable:
+    - musttag
 
 linters-settings:
   exhaustive:


### PR DESCRIPTION
The musttag checker exits with status code 1 and kills the linter pipeline. Since nothing else is logged, disabling it seems to be the only fix for now. Running golangci-lint locally does not cause this issue, so it looks like a problem with the specific version of `musttag` that's being used in the GitHub action. I'll ping the golangci folks and let them know about this.