### PR TITLE
ci: add markdown linter

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -3,7 +3,7 @@ on: [ push, pull_request ]
 
 jobs:
   lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
     - uses: golangci/golangci-lint-action@v3
@@ -13,10 +13,29 @@ jobs:
         only-new-issues: true
 
   gomod:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
     - name: verify go.mod/go.sum
       run: |
         go mod tidy
         git diff --exit-code
+
+  lint_markdown:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+    - uses: actions/checkout@v3
+    - uses: dorny/paths-filter@v2
+      id: changes
+      with:
+        filters: |
+          md:
+            - 'README.md'
+    - name: Lint markdown
+      if: steps.changes.outputs.md == 'true'
+      uses: DavidAnson/markdownlint-cli2-action@v9
+      with:
+        globs: |
+          README.md

--- a/README.md
+++ b/README.md
@@ -1,18 +1,22 @@
+<!-- markdownlint-configure-file { "no-hard-tabs": { "code_blocks": false } } -->
+# go-criu -- Go bindings for CRIU
+
 [![test](https://github.com/checkpoint-restore/go-criu/workflows/ci/badge.svg?branch=master)](https://github.com/checkpoint-restore/go-criu/actions?query=workflow%3Aci)
 [![verify](https://github.com/checkpoint-restore/go-criu/workflows/verify/badge.svg?branch=master)](https://github.com/checkpoint-restore/go-criu/actions?query=workflow%3Averify)
 [![Go Reference](https://pkg.go.dev/badge/github.com/checkpoint-restore/go-criu.svg)](https://pkg.go.dev/github.com/checkpoint-restore/go-criu)
 
-## go-criu -- Go bindings for CRIU
-
 This repository provides Go bindings for [CRIU](https://criu.org/).
 The code is based on the Go-based PHaul implementation from the CRIU repository.
-For easier inclusion into other Go projects, the CRIU Go bindings have been moved to this repository.
+For easier inclusion into other Go projects, the CRIU Go bindings have been
+moved to this repository.
 
-### CRIU
+## CRIU
+
 The Go bindings provide an easy way to use the CRIU RPC calls from Go without
 the need to set up all the infrastructure to make the actual RPC connection to CRIU.
 
 The following example would print the version of CRIU:
+
 ```go
 import (
 	"log"
@@ -37,12 +41,12 @@ or to just check if at least a certain CRIU version is installed:
 	result, err := c.IsCriuAtLeast(31100)
 ```
 
-### CRIT
+## CRIT
 
 The `crit` package provides bindings to decode, encode, and manipulate
 CRIU image files natively within Go. It also provides a CLI tool similar
 to the original CRIT Python tool. To get started with this, see the docs
-at https://criu.org/CRIT_(Go_library).
+at [CRIT (Go library)](https://criu.org/CRIT_%28Go_library%29).
 
 ## Releases
 
@@ -75,6 +79,7 @@ break-up larger PRs into smaller ones - it's easier to review smaller
 code changes. But only if those smaller ones make sense as stand-alone PRs.
 
 Regardless of the type of PR, all PRs should include:
+
 * well documented code changes
 * additional testcases. Ideally, they should fail w/o your code change applied
 * documentation changes


### PR DESCRIPTION
This introduces a markdown linter for the go-criu repo. It runs only if a PR modifies any of the README.md files present. The commit also fixes the initial issues raised on the top-level readme.

cc @adrianreber 