### PR TITLE
ci: fix protoc-gen-go path for go install

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -33,7 +33,7 @@ jobs:
 
     - name: Install protoc-gen-go
       run: |
-        sudo env "GOBIN=/usr/bin" go install github.com/golang/protobuf/protoc-gen-go@latest
+        sudo env "GOBIN=/usr/bin" go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
 
     - name: Test go-criu
       run: sudo -E make test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,20 +13,20 @@ jobs:
 
     steps:
 
-    - name: checkout
+    - name: Checkout
       uses: actions/checkout@v3
       with:
         # needed for codecov
         fetch-depth: 0
 
-    - name: build criu ${{ matrix.criu_branch }}
+    - name: Build CRIU ${{ matrix.criu_branch }}
       run: |
         sudo apt-get install -y libprotobuf-dev libprotobuf-c-dev protobuf-c-compiler protobuf-compiler python3-protobuf libnl-3-dev libnet-dev libcap-dev curl unzip
         git clone --depth=1 --single-branch -b ${{ matrix.criu_branch }} https://github.com/checkpoint-restore/criu.git
         make -j"$(nproc)" -C criu
         sudo make -C criu install-criu PREFIX=/usr
 
-    - name: install go ${{ matrix.go-version }}
+    - name: Install Go ${{ matrix.go-version }}
       uses: actions/setup-go@v4
       with:
         go-version: ${{ matrix.go-version }}
@@ -41,7 +41,7 @@ jobs:
     - name: Test magicgen script
       run: sudo -E make -C scripts test
 
-    - name: Test crit
+    - name: Test CRIT
       run: |
         if [ "${{ matrix.criu_branch }}" = "criu-dev" ]; then
           # We need to use the protobuf definitions from the criu-dev


### PR DESCRIPTION
The CI job that installed protoc-gen-go was using a deprecated package path. It has been updated with the path to the active package path.

cc @rst0git