### PR TITLE
make: fix test execution

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -15,8 +15,8 @@ COVERAGE_BINARIES := test.coverage phaul/phaul.coverage
 all: $(TEST_BINARIES) phaul-test
 	mkdir -p image
 	PID=$$(piggie/piggie) && { \
-	test dump $$PID image && \
-	test restore image; \
+	./test dump $$PID image && \
+	./test restore image; \
 	pkill -9 piggie; \
 	}
 	rm -rf image


### PR DESCRIPTION
`make test` currently shows the following error:

```
/bin/bash: line 2: test: 8349: binary operator expected
```

To execute the `test` binary, we need to use relative path.