### PR TITLE
ci: fix coverage

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -7,6 +7,7 @@ CRIU_FEATURE_LAZY_PAGES = $(shell if criu check --feature uffd-noncoop > /dev/nu
 CRIU_FEATURE_PIDFD_STORE = $(shell if criu check --feature pidfd_store > /dev/null; then echo 1; else echo 0; fi)
 
 export CRIU_FEATURE_MEM_TRACK CRIU_FEATURE_LAZY_PAGES CRIU_FEATURE_PIDFD_STORE
+export GOCOVERDIR=$(COVERAGE_PATH)
 
 TEST_PAYLOAD := piggie/piggie
 TEST_BINARIES := test $(TEST_PAYLOAD) phaul/phaul

--- a/test/Makefile
+++ b/test/Makefile
@@ -60,13 +60,13 @@ coverage: $(COVERAGE_BINARIES) $(TEST_PAYLOAD)
 	mkdir -p $(COVERAGE_PATH)
 	mkdir -p image
 	PID=$$(piggie/piggie) && { \
-	./test.coverage -test.coverprofile=coverprofile.integration.$$RANDOM -test.outputdir=${COVERAGE_PATH} COVERAGE dump $$PID image && \
-	./test.coverage -test.coverprofile=coverprofile.integration.$$RANDOM -test.outputdir=${COVERAGE_PATH} COVERAGE restore image; \
+	./test.coverage -test.v -test.coverprofile=coverprofile.integration.$$RANDOM -test.outputdir=${COVERAGE_PATH} COVERAGE dump $$PID image && \
+	./test.coverage -test.v -test.coverprofile=coverprofile.integration.$$RANDOM -test.outputdir=${COVERAGE_PATH} COVERAGE restore image; \
 	pkill -9 piggie; \
 	}
 	rm -rf image
 	PID=$$(piggie/piggie) && { \
-	phaul/phaul.coverage -test.coverprofile=coverprofile.integration.$$RANDOM -test.outputdir=${COVERAGE_PATH} COVERAGE $$PID; \
+	phaul/phaul.coverage -test.v -test.coverprofile=coverprofile.integration.$$RANDOM -test.outputdir=${COVERAGE_PATH} COVERAGE $$PID; \
 	pkill -9 piggie; \
 	}
 	echo "mode: set" > .coverage/coverage.out && cat .coverage/coverprofile* | \

--- a/test/Makefile
+++ b/test/Makefile
@@ -61,7 +61,7 @@ coverage: $(COVERAGE_BINARIES) $(TEST_PAYLOAD)
 	mkdir -p $(COVERAGE_PATH)
 	mkdir -p image
 	PID=$$(piggie/piggie) && { \
-	./test.coverage -test.v -test.coverprofile=${COVERAGE_PATH}/coverprofile.integration.$$RANDOM COVERAGE dump $$PID image && \
+	./test.coverage -test.v -test.coverprofile=${COVERAGE_PATH}/coverprofile.integration.$$RANDOM COVERAGE dump $$PID image || echo ">> Dump exit code $$?"; \
 	./test.coverage -test.v -test.coverprofile=${COVERAGE_PATH}/coverprofile.integration.$$RANDOM COVERAGE restore image; \
 	pkill -9 piggie; \
 	}

--- a/test/Makefile
+++ b/test/Makefile
@@ -61,22 +61,22 @@ coverage: $(COVERAGE_BINARIES) $(TEST_PAYLOAD)
 	mkdir -p $(COVERAGE_PATH)
 	mkdir -p image
 	PID=$$(piggie/piggie) && { \
-	./test.coverage -test.v -test.coverprofile=coverprofile.integration.$$RANDOM -test.outputdir=${COVERAGE_PATH} COVERAGE dump $$PID image && \
-	./test.coverage -test.v -test.coverprofile=coverprofile.integration.$$RANDOM -test.outputdir=${COVERAGE_PATH} COVERAGE restore image; \
+	./test.coverage -test.v -test.coverprofile=${COVERAGE_PATH}/coverprofile.integration.$$RANDOM COVERAGE dump $$PID image && \
+	./test.coverage -test.v -test.coverprofile=${COVERAGE_PATH}/coverprofile.integration.$$RANDOM COVERAGE restore image; \
 	pkill -9 piggie; \
 	}
 	rm -rf image
 	PID=$$(piggie/piggie) && { \
-	phaul/phaul.coverage -test.v -test.coverprofile=coverprofile.integration.$$RANDOM -test.outputdir=${COVERAGE_PATH} COVERAGE $$PID; \
+	phaul/phaul.coverage -test.v -test.coverprofile=${COVERAGE_PATH}/coverprofile.integration.$$RANDOM COVERAGE $$PID; \
 	pkill -9 piggie; \
 	}
-	echo "mode: set" > .coverage/coverage.out && cat .coverage/coverprofile* | \
-		grep -v mode: | sort -r | awk '{if($$1 != last) {print $$0;last=$$1}}' >> .coverage/coverage.out
+	echo "mode: set" > ${COVERAGE_PATH}/coverage.out && cat ${COVERAGE_PATH}/coverprofile* | \
+		grep -v mode: | sort -r | awk '{if($$1 != last) {print $$0;last=$$1}}' >> ${COVERAGE_PATH}/coverage.out
 
 codecov:
 	curl -Os https://uploader.codecov.io/latest/linux/codecov
 	chmod +x codecov
-	./codecov -f '.coverage/coverage.out'
+	./codecov -f ${COVERAGE_PATH}/coverage.out
 
 clean:
 	@rm -f $(TEST_BINARIES) $(COVERAGE_BINARIES) codecov


### PR DESCRIPTION
For some reason, `./test.coverage ... COVERAGE dump $$PID image` has exit code 2, despite the test cases being successful and `criu dump` working as expected. This is a temporary work-around to ignore this exit code.