### PR TITLE
test: enable coverage of crit unit/e2e tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,6 +54,7 @@ jobs:
           make -C crit gen-proto
           sudo -E make -C crit all
         fi
+        sudo -E make -C crit unit-test
         sudo -E make -C test crit-test
 
     - name: Check code coverage

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ scripts/*.h
 scripts/expected.go
 scripts/output.go
 crit/bin
+crit/test-imgs/

--- a/crit/Makefile
+++ b/crit/Makefile
@@ -40,8 +40,8 @@ gen-proto:
 bin/crit: cmd/cli.go
 	$(GO) build ${GOFLAGS} -o $@ $^
 
-../test/loop/loop: ../test/loop/loop.c
-	$(CC) $^ -o $@
+../test/loop/loop:
+	$(MAKE) -C ../test/loop
 
 test-imgs: ../test/loop/loop
 	$(eval PID := $(shell ../test/loop/loop))

--- a/crit/Makefile
+++ b/crit/Makefile
@@ -51,6 +51,7 @@ test-imgs: ../test/loop/loop
 	pkill -9 loop
 
 unit-test: test-imgs
+	$(eval GOFLAGS ?= -cover)
 	go test ${GOFLAGS} -v ./...
 
 clean:

--- a/crit/Makefile
+++ b/crit/Makefile
@@ -1,4 +1,5 @@
 GO ?= go
+CRIU ?= criu
 
 # The import path that protoc will use if a proto file imports another one
 import_path := github.com/checkpoint-restore/go-criu/crit/images
@@ -39,7 +40,21 @@ gen-proto:
 bin/crit: cmd/cli.go
 	$(GO) build -o $@ $^
 
-clean:
-	rm -f bin/crit
+../test/loop/loop: ../test/loop/loop.c
+	$(CC) $^ -o $@
 
-.PHONY: all gen-proto update-proto clean
+test-imgs: ../test/loop/loop
+	$(eval PID := $(shell ../test/loop/loop))
+	mkdir -p $@
+	$(CRIU) dump -v4 -o dump.log -D $@ -t $(PID)
+	$(CRIU) restore -v4 -o restore.log -D $@ -d
+	pkill -9 loop
+
+unit-test: test-imgs
+	go test ${GOFLAGS} -v ./...
+
+clean:
+	@rm -f bin/crit
+	@rm -rf test-imgs
+
+.PHONY: all gen-proto update-proto unit-test clean

--- a/crit/Makefile
+++ b/crit/Makefile
@@ -38,7 +38,7 @@ gen-proto:
 		$(proto_files)
 
 bin/crit: cmd/cli.go
-	$(GO) build -o $@ $^
+	$(GO) build ${GOFLAGS} -o $@ $^
 
 ../test/loop/loop: ../test/loop/loop.c
 	$(CC) $^ -o $@

--- a/crit/stats_test.go
+++ b/crit/stats_test.go
@@ -1,13 +1,9 @@
-package main
+package crit
 
-import (
-	"testing"
-
-	"github.com/checkpoint-restore/go-criu/v6/crit"
-)
+import "testing"
 
 func TestGetDumpStats(t *testing.T) {
-	dumpStats, err := crit.GetDumpStats("test-imgs")
+	dumpStats, err := GetDumpStats("test-imgs")
 	if err != nil {
 		t.Error("Failed to get stats")
 	}
@@ -17,7 +13,7 @@ func TestGetDumpStats(t *testing.T) {
 }
 
 func TestGetRestoreStats(t *testing.T) {
-	restoreStats, err := crit.GetRestoreStats("test-imgs")
+	restoreStats, err := GetRestoreStats("test-imgs")
 	if err != nil {
 		t.Error("Failed to get stats")
 	}

--- a/test/Makefile
+++ b/test/Makefile
@@ -88,10 +88,16 @@ coverage: check-go-version $(COVERAGE_BINARIES) $(TEST_PAYLOAD)
 	pkill -9 piggie; \
 	}
 	cd crit/ && GOCOVERDIR=${COVERAGE_PATH} ./crit-test.coverage
+	$(MAKE) -C ../crit/ unit-test GOFLAGS="-coverprofile=${COVERAGE_PATH}/coverprofile-crit-unit-test"
 	$(MAKE) -C crit/ clean
 	# Print coverage from this run
 	$(GO) tool covdata percent -i=${COVERAGE_PATH}
 	$(GO) tool covdata textfmt -i=${COVERAGE_PATH} -o ${COVERAGE_PATH}/coverage.out
+	# The coverage from 'go test' is stored in coverprofile-*,
+	# but we upload only 'coverage.out' with codecov. Here we
+	# combine the coverage results to show up in GitHub.
+	cat .coverage/coverprofile* | \
+		grep -v mode: | sort -r | awk '{if($$1 != last) {print $$0;last=$$1}}' >> ${COVERAGE_PATH}/coverage.out
 
 codecov:
 	curl -Os https://uploader.codecov.io/latest/linux/codecov

--- a/test/Makefile
+++ b/test/Makefile
@@ -68,7 +68,10 @@ phaul/phaul.coverage: check-go-version phaul/*.go
 		-o $@ phaul/main.go
 
 crit/crit-test.coverage: check-go-version crit/*.go
-	$(MAKE) -C ../crit bin/crit
+	# Re-build the crit binary, so that test coverage
+	# works even if we run `make test` before that.
+	$(MAKE) -C ../crit clean
+	$(MAKE) -C ../crit bin/crit GOFLAGS="-cover"
 	$(MAKE) -C crit/ test-imgs
 	$(GO) build \
 		-cover \
@@ -89,6 +92,7 @@ coverage: check-go-version $(COVERAGE_BINARIES) $(TEST_PAYLOAD)
 	}
 	cd crit/ && GOCOVERDIR=${COVERAGE_PATH} ./crit-test.coverage
 	$(MAKE) -C ../crit/ unit-test GOFLAGS="-coverprofile=${COVERAGE_PATH}/coverprofile-crit-unit-test"
+	$(MAKE) -C crit/ e2e-test GOCOVERDIR=${COVERAGE_PATH}
 	$(MAKE) -C crit/ clean
 	# Print coverage from this run
 	$(GO) tool covdata percent -i=${COVERAGE_PATH}

--- a/test/crit/Makefile
+++ b/test/crit/Makefile
@@ -20,7 +20,7 @@ test-imgs: ../loop/loop
 	pkill -9 loop
 
 ../../crit/bin/crit:
-	$(MAKE) -C ../../crit bin/crit
+	$(MAKE) -C ../../crit bin/crit GOFLAGS="${GOFLAGS}"
 
 ../loop/loop: ../loop/loop.c
 	$(CC) $^ -o $@

--- a/test/crit/Makefile
+++ b/test/crit/Makefile
@@ -2,10 +2,7 @@ CC ?= gcc
 GO ?= go
 CRIU ?= criu
 
-all: unit-test integration-test e2e-test clean
-
-unit-test: test-imgs
-	go test -v ./...
+all: integration-test e2e-test clean
 
 integration-test: test-imgs crit-test
 	@echo "Running integration test"
@@ -34,4 +31,4 @@ crit-test: main.go
 clean:
 	@rm -rf test-imgs
 
-.PHONY: all test unit-test integration-test e2e-test clean
+.PHONY: all test integration-test e2e-test clean

--- a/test/crit/Makefile
+++ b/test/crit/Makefile
@@ -1,4 +1,3 @@
-CC ?= gcc
 GO ?= go
 CRIU ?= criu
 
@@ -22,8 +21,8 @@ test-imgs: ../loop/loop
 ../../crit/bin/crit:
 	$(MAKE) -C ../../crit bin/crit GOFLAGS="${GOFLAGS}"
 
-../loop/loop: ../loop/loop.c
-	$(CC) $^ -o $@
+../loop/loop:
+	$(MAKE) -C ../loop
 
 crit-test: main.go
 	$(GO) build -v -o $@ $^

--- a/test/loop/Makefile
+++ b/test/loop/Makefile
@@ -1,0 +1,4 @@
+CC ?= gcc
+
+loop: loop.c
+	$(CC) $^ -o $@


### PR DESCRIPTION
This pull request enables code coverage for CRIT's [unit](https://go.dev/blog/cover) and [e2e](https://go.dev/testing/coverage/) tests.