### PR TITLE
ci: cancel preceding workflows run

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,11 @@ name: ci
 
 on: [push, pull_request]
 
+# Cancel any preceding run on the pull request.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request adds a concurrency group to the main CI workflow to automatically cancel any in-progress workflows when a pull request has been updated.

This [concurrency group](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency) ensures that a single workflow will run at a time. For example, when a pull request is updated with a force-push, the GiHub CI workflows currently in-progress will be automatically cancelled, and the CI would run only with the updated commits.

An exception is used for the 'master' branch, so that when multiple pull requests have been merged, the CI would run for each merge commit.