### PR TITLE
feat(crit): add type to file descriptor

### DIFF
--- a/crit/explore.go
+++ b/crit/explore.go
@@ -77,6 +77,7 @@ type Fd struct {
 // File represents a single opened file
 type File struct {
 	Fd   string `json:"fd"`
+	Type string `json:"type,omitempty"`
 	Path string `json:"path"`
 }
 
@@ -114,6 +115,7 @@ func (c *crit) ExploreFds() ([]*Fd, error) {
 			}
 			file := File{
 				Fd:   strconv.FormatUint(uint64(fdInfo.GetFd()), 10),
+				Type: fdInfo.GetType().String(),
 				Path: filePath,
 			}
 			fdEntry.Files = append(fdEntry.Files, &file)

--- a/crit/utils.go
+++ b/crit/utils.go
@@ -139,7 +139,7 @@ func getFilePath(dir string, fID uint32, fType fdinfo.FdTypes) (string, error) {
 	case fdinfo.FdTypes_UNIXSK:
 		filePath, err = getUnixSkFilePath(dir, file, fID)
 	default:
-		filePath = fmt.Sprintf("%s.%d", fdinfo.FdTypes_name[int32(fType)], fID)
+		filePath = fmt.Sprintf("%s.%d", fType.String(), fID)
 	}
 
 	return filePath, err


### PR DESCRIPTION
This would be useful for us to extend the info displayed by checkpointctl. Since we're anyway holding the information with us in the object, we might as well just provide that information too.