### PR TITLE
chore(crit): improve Makefile rule

### DIFF
--- a/crit/Makefile
+++ b/crit/Makefile
@@ -1,8 +1,10 @@
 GO ?= go
 CRIU ?= criu
+CRIT_SRC := $(shell find . -type f -name '*.go')
+CRIT_CLI := cmd/main.go
 
-bin/crit: cmd/main.go
-	$(GO) build ${GOFLAGS} -o $@ $^
+bin/crit: $(CRIT_SRC)
+	$(GO) build ${GOFLAGS} -o $@ $(CRIT_CLI)
 
 ../test/loop/loop:
 	$(MAKE) -C ../test/loop


### PR DESCRIPTION
Previously, the Makefile in `crit` would not rebuild the binary even if any of the related source files changed. This is now fixed by marking all Go files under the directory as prerequisites for the `bin/crit` recipe.