### PR TITLE
crit: add getter for `pagesID` field in `MemoryReader` struct

### DIFF
--- a/crit/mempages.go
+++ b/crit/mempages.go
@@ -24,6 +24,10 @@ type MemoryReader struct {
 	pagemapEntries []*pagemap.PagemapEntry
 }
 
+func (mr *MemoryReader) GetPagesID() uint32 {
+	return mr.pagesID
+}
+
 // NewMemoryReader creates a new instance of MemoryReader with all the fields populated
 func NewMemoryReader(checkpointDir string, pid uint32, pageSize int) (*MemoryReader, error) {
 	if pageSize == 0 {


### PR DESCRIPTION
This commit introduces a getter function that allows accessing the value of the `pagesID` field within the `MemoryReader` struct. This function will be beneficial for enabling `checkpointctl` to extract only the required page image files efficiently.