### PR TITLE
feat: propagating ciru rpc response

### DIFF
--- a/main.go
+++ b/main.go
@@ -86,17 +86,17 @@ func (c *Criu) sendAndRecv(reqB []byte) ([]byte, int, error) {
 	return respB, n, nil
 }
 
-func (c *Criu) doSwrk(reqType rpc.CriuReqType, opts *rpc.CriuOpts, nfy Notify) error {
+func (c *Criu) doSwrk(reqType rpc.CriuReqType, opts *rpc.CriuOpts, nfy Notify) (*rpc.CriuResp, error) {
 	resp, err := c.doSwrkWithResp(reqType, opts, nfy, nil)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	respType := resp.GetType()
 	if respType != reqType {
-		return errors.New("unexpected CRIU RPC response")
+		return nil, errors.New("unexpected CRIU RPC response")
 	}
 
-	return nil
+	return resp, nil
 }
 
 func (c *Criu) doSwrkWithResp(reqType rpc.CriuReqType, opts *rpc.CriuOpts, nfy Notify, features *rpc.CriuFeatures) (*rpc.CriuResp, error) {
@@ -192,22 +192,23 @@ func (c *Criu) doSwrkWithResp(reqType rpc.CriuReqType, opts *rpc.CriuOpts, nfy N
 }
 
 // Dump dumps a process
-func (c *Criu) Dump(opts *rpc.CriuOpts, nfy Notify) error {
+func (c *Criu) Dump(opts *rpc.CriuOpts, nfy Notify) (*rpc.CriuResp, error) {
 	return c.doSwrk(rpc.CriuReqType_DUMP, opts, nfy)
+
 }
 
 // Restore restores a process
-func (c *Criu) Restore(opts *rpc.CriuOpts, nfy Notify) error {
+func (c *Criu) Restore(opts *rpc.CriuOpts, nfy Notify) (*rpc.CriuResp, error) {
 	return c.doSwrk(rpc.CriuReqType_RESTORE, opts, nfy)
 }
 
 // PreDump does a pre-dump
-func (c *Criu) PreDump(opts *rpc.CriuOpts, nfy Notify) error {
+func (c *Criu) PreDump(opts *rpc.CriuOpts, nfy Notify) (*rpc.CriuResp, error) {
 	return c.doSwrk(rpc.CriuReqType_PRE_DUMP, opts, nfy)
 }
 
 // StartPageServer starts the page server
-func (c *Criu) StartPageServer(opts *rpc.CriuOpts) error {
+func (c *Criu) StartPageServer(opts *rpc.CriuOpts) (*rpc.CriuResp, error) {
 	return c.doSwrk(rpc.CriuReqType_PAGE_SERVER, opts, nil)
 }
 

--- a/test/main.go
+++ b/test/main.go
@@ -47,9 +47,9 @@ func doDump(c *criu.Criu, pidS string, imgDir string, pre bool, prevImg string) 
 	}
 
 	if pre {
-		err = c.PreDump(opts, TestNfy{})
+		_, err = c.PreDump(opts, TestNfy{})
 	} else {
-		err = c.Dump(opts, TestNfy{})
+		_, err = c.Dump(opts, TestNfy{})
 	}
 	if err != nil {
 		return fmt.Errorf("dump fail: %w", err)
@@ -190,7 +190,7 @@ func main() {
 			LogFile:     proto.String("restore.log"),
 		}
 
-		err = c.Restore(opts, nil)
+		_, err = c.Restore(opts, nil)
 		if err != nil {
 			log.Fatalln("restore failed:", err)
 		}

--- a/test/phaul/main.go
+++ b/test/phaul/main.go
@@ -108,7 +108,8 @@ func (r *testRemote) doRestore() error {
 
 	cr := r.srv.GetCriu()
 	fmt.Printf("Do restore\n")
-	return cr.Restore(opts, nil)
+	_, err = cr.Restore(opts, nil)
+	return err
 }
 
 func (l *testLocal) PostDump() error {
@@ -139,7 +140,8 @@ func (l *testLocal) DumpCopyRestore(cr *criu.Criu, cfg phaul.Config, lastClnImag
 	}
 
 	fmt.Printf("Do dump\n")
-	return cr.Dump(opts, l)
+	_, err = cr.Dump(opts, l)
+	return err
 }
 
 func main() {


### PR DESCRIPTION
This PR is aimed to return the resp from `c.doSwrk`. It's motivated primarily by the need to access the PID of the restored process, which isn't straightforward to do without getting the result from `resp` directly. 