### PR TITLE
chore: fix lints from `protogetter`

### DIFF
--- a/crit/explore.go
+++ b/crit/explore.go
@@ -47,7 +47,7 @@ func (c *crit) ExplorePs() (*PsTree, error) {
 			PID:     pID,
 			PgID:    process.GetPgid(),
 			SID:     process.GetSid(),
-			Comm:    coreData.Tc.GetComm(),
+			Comm:    coreData.GetTc().GetComm(),
 			Process: process,
 			Core:    coreData,
 		}

--- a/crit/mempages.go
+++ b/crit/mempages.go
@@ -120,7 +120,7 @@ func (mr *MemoryReader) getPage(pageNo uint64) ([]byte, error) {
 	// Iterate over pagemap entries to find the corresponding page
 	for _, m := range mr.pagemapEntries {
 		found := false
-		for i := 0; i < int(*m.NrPages); i++ {
+		for i := 0; i < int(m.GetNrPages()); i++ {
 			if m.GetVaddr()+uint64(i)*uint64(mr.pageSize) == pageNo*uint64(mr.pageSize) {
 				found = true
 				break
@@ -157,7 +157,7 @@ func (mr *MemoryReader) GetPsArgs() (*bytes.Buffer, error) {
 	}
 	mm := mmImg.Entries[0].Message.(*mm.MmEntry)
 
-	return mr.GetMemPages(*mm.MmArgStart, *mm.MmArgEnd)
+	return mr.GetMemPages(mm.GetMmArgStart(), mm.GetMmArgEnd())
 }
 
 // GetPsArgs retrieves process environment variables from memory pages.
@@ -168,7 +168,7 @@ func (mr *MemoryReader) GetPsEnvVars() (*bytes.Buffer, error) {
 	}
 	mm := mmImg.Entries[0].Message.(*mm.MmEntry)
 
-	return mr.GetMemPages(*mm.MmEnvStart, *mm.MmEnvEnd)
+	return mr.GetMemPages(mm.GetMmEnvStart(), mm.GetMmEnvEnd())
 }
 
 func (mr *MemoryReader) GetPagemapEntries() []*pagemap.PagemapEntry {
@@ -184,7 +184,7 @@ func (mr *MemoryReader) GetShmemSize() (int64, error) {
 
 	var size int64
 	mm := mmImg.Entries[0].Message.(*mm.MmEntry)
-	for _, vma := range mm.Vmas {
+	for _, vma := range mm.GetVmas() {
 		// Check if VMA has the MAP_SHARED flag set in its flags
 		if vma.GetFlags()&unix.MAP_SHARED != 0 {
 			size += int64(vma.GetEnd() - vma.GetStart())

--- a/main.go
+++ b/main.go
@@ -218,7 +218,7 @@ func (c *Criu) StartPageServerChld(opts *rpc.CriuOpts) (int, int, error) {
 		return 0, 0, err
 	}
 
-	return int(resp.Ps.GetPid()), int(resp.Ps.GetPort()), nil
+	return int(resp.GetPs().GetPid()), int(resp.GetPs().GetPort()), nil
 }
 
 // GetCriuVersion executes the VERSION RPC call and returns the version
@@ -233,19 +233,19 @@ func (c *Criu) GetCriuVersion() (int, error) {
 		return 0, fmt.Errorf("unexpected CRIU RPC response")
 	}
 
-	version := int(*resp.GetVersion().MajorNumber) * 10000
-	version += int(*resp.GetVersion().MinorNumber) * 100
-	if resp.GetVersion().Sublevel != nil {
-		version += int(*resp.GetVersion().Sublevel)
+	version := resp.GetVersion().GetMajorNumber() * 10000
+	version += resp.GetVersion().GetMinorNumber() * 100
+	if resp.GetVersion().GetSublevel() != 0 {
+		version += resp.GetVersion().GetSublevel()
 	}
 
-	if resp.GetVersion().Gitid != nil {
+	if resp.GetVersion().GetGitid() != "" {
 		// taken from runc: if it is a git release -> increase minor by 1
 		version -= (version % 100)
 		version += 100
 	}
 
-	return version, nil
+	return int(version), nil
 }
 
 // IsCriuAtLeast checks if the version is at least the same

--- a/test/main.go
+++ b/test/main.go
@@ -102,27 +102,27 @@ func featureCheck(c *criu.Criu) error {
 		return err
 	}
 
-	if *features.MemTrack != *featuresToCompare.MemTrack {
+	if features.GetMemTrack() != featuresToCompare.GetMemTrack() {
 		return fmt.Errorf(
 			"unexpected MemTrack FeatureCheck result %v:%v",
-			*features.MemTrack,
-			*featuresToCompare.MemTrack,
+			features.GetMemTrack(),
+			featuresToCompare.GetMemTrack(),
 		)
 	}
 
-	if *features.LazyPages != *featuresToCompare.LazyPages {
+	if features.GetLazyPages() != featuresToCompare.GetLazyPages() {
 		return fmt.Errorf(
 			"unexpected LazyPages FeatureCheck result %v:%v",
-			*features.LazyPages,
-			*featuresToCompare.LazyPages,
+			features.GetLazyPages(),
+			featuresToCompare.GetLazyPages(),
 		)
 	}
 
-	if *features.PidfdStore != *featuresToCompare.PidfdStore {
+	if features.GetPidfdStore() != featuresToCompare.GetPidfdStore() {
 		return fmt.Errorf(
 			"unexpected PidfdStore FeatureCheck result %v:%v",
-			*features.PidfdStore,
-			*featuresToCompare.PidfdStore,
+			features.GetPidfdStore(),
+			featuresToCompare.GetPidfdStore(),
 		)
 	}
 


### PR DESCRIPTION
The new version of golangci-lint enables a new linter, which checks for direct access to protobuf fields. The offending instances have now been fixed.