### PR TITLE
fix(crit): use proto names in JSON

### DIFF
--- a/crit/image.go
+++ b/crit/image.go
@@ -34,7 +34,7 @@ func (c *CriuEntry) MarshalJSON() ([]byte, error) {
 		return []byte(fmt.Sprint(`{"count":"`, c.Extra, `"}`)), nil
 	}
 
-	data, err := protojson.Marshal(c.Message)
+	data, err := protojson.MarshalOptions{UseProtoNames: true}.Marshal(c.Message)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Previously, the JSON output generated through `protojson.Marshal` was using camelCased names for the keys. It now uses snake_case, which is consistent with the behaviour of the Python implementation of CRIT.

Closes #154

cc @rst0git 