### PR TITLE
feat(crit): add SearchPattern method on MemoryReader

### DIFF
--- a/test/loop/loop.c
+++ b/test/loop/loop.c
@@ -12,6 +12,13 @@ int main(void)
 	int res = EXIT_FAILURE;
 	int start_pipe[2];
 
+	// Set a PASSWORD environment variable to test the search pattern
+	// within process memory pages using regex metacharacters.
+	if (setenv("PASSWORD", "123 Hello.*?[^]@WORLD(|x)", 1) != 0) {
+		perror("setenv");
+		return 1;
+	}
+
 	if (pipe(start_pipe)) {
 		perror("pipe failed!");
 		goto out;


### PR DESCRIPTION
I am currently working on a feature to allow users to search for a pattern within process memory pages, as suggested by @rst0git last year. This could be used to extend `checkpointctl memparse` with search capability. 

Currently, the method `SearchPattern(pattern string) (uint64, error)` takes the pattern to search as an argument and returns the address of the first match along with an error if the pattern is not found. I am not sure about the implementation yet, and I'm considering alternative approaches:

- Instead of providing just the address of the first match, should we consider returning the entire memory pages where the pattern is found?

- Another consideration is whether to return not just the first match but all occurrences of the pattern.

@rst0git, @adrianreber , @snprajwal  PTAL.