### PR TITLE
Add functions which are used in Podman, CRI-O and containerd

### DIFF
--- a/utils/criu.go
+++ b/utils/criu.go
@@ -1,0 +1,8 @@
+package utils
+
+// MinCriuVersion for Podman at least CRIU 3.11 is required
+const MinCriuVersionPodman = 31100
+
+// PodCriuVersion is the version of CRIU needed for
+// checkpointing and restoring containers out of and into Pods.
+const PodCriuVersion = 31600

--- a/utils/criu_linux.go
+++ b/utils/criu_linux.go
@@ -1,0 +1,42 @@
+package utils
+
+import (
+	"fmt"
+
+	"github.com/checkpoint-restore/go-criu/v7"
+	"github.com/checkpoint-restore/go-criu/v7/rpc"
+	"google.golang.org/protobuf/proto"
+)
+
+// CheckForCRIU checks if CRIU is available and if it is as least the
+// version as specified in the "version" parameter.
+func CheckForCriu(version int) error {
+	criuVersion, err := GetCriuVersion()
+	if err != nil {
+		return fmt.Errorf("failed to check for criu version: %w", err)
+	}
+
+	if criuVersion >= version {
+		return nil
+	}
+	return fmt.Errorf("checkpoint/restore requires at least CRIU %d, current version is %d", version, criuVersion)
+}
+
+// Convenience function to easily check if memory tracking is supported.
+func IsMemTrack() bool {
+	features, err := criu.MakeCriu().FeatureCheck(
+		&rpc.CriuFeatures{
+			MemTrack: proto.Bool(true),
+		},
+	)
+	if err != nil {
+		return false
+	}
+
+	return features.GetMemTrack()
+}
+
+func GetCriuVersion() (int, error) {
+	c := criu.MakeCriu()
+	return c.GetCriuVersion()
+}

--- a/utils/criu_unsupported.go
+++ b/utils/criu_unsupported.go
@@ -1,0 +1,18 @@
+//go:build !linux
+// +build !linux
+
+package utils
+
+import "fmt"
+
+func CheckForCriu(version int) error {
+	return fmt.Errorf("CRIU not supported on this platform")
+}
+
+func IsMemTrack() bool {
+	return false
+}
+
+func GetCriuVersion() (int, error) {
+	return 0, fmt.Errorf("CRIU not supported in this platform")
+}


### PR DESCRIPTION
Convenience functions to check if CRIU is available and at least a certain version are now used in containerd, CRI-O and Podman. This change moves those functions to go-criu.

I am not entirely sure about the naming and the location. If this used somewhere else it would be:
```
import "github.com/checkpoint-restore/go-criu/v7/utils"
...
utils.GetCriuVersion()
```
Which results in `utils`, which is a very generic name. Maybe changing the directory name to `crutils` would be better?

```
import "github.com/checkpoint-restore/go-criu/v7/crutils"
...
crutils.GetCriuVersion()
```

Not sure. Any ideas about naming to make it easy to include and understand where it is coming from?