### PR TITLE
fix(coverage): ignore test files

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "test"


### PR DESCRIPTION
Codecov ignores unit tests by default, but does not recognise the `test` directory for integration tests. Tests are written to generate coverage, so it does not make sense to check the coverage of the tests themselves.