### PR TITLE
release: v7.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The following table shows the relation between go-criu and criu versions:
 
 | Major version  | Latest release | CRIU version |
 | -------------- | -------------- | ------------ |
-| v7             | 7.0.0          | 3.18         |
+| v7             | 7.1.0          | 3.18         |
 | v6             | 6.3.0          | 3.17         |
 | v5             | 5.3.0          | 3.16         |
 | v5             | 5.0.0          | 3.15         |


### PR DESCRIPTION
Just bumps the README before tagging the release. Closes #167 