### PR TITLE
criu swrk: return child error to caller

### DIFF
--- a/test/main.go
+++ b/test/main.go
@@ -202,7 +202,10 @@ func main() {
 			log.Fatalln("dump failed: ", err)
 		}
 
-		c.Cleanup()
+		err = c.Cleanup()
+		if err != nil {
+			log.Fatalln("cleanup failed: ", err)
+		}
 	case "restore":
 		log.Println("Restoring")
 		img, err := os.Open(os.Args[2])


### PR DESCRIPTION
In the podman CI we are seeing a weird flake during criu version detection[1]. The write to the socket just fails with broken pipe. The logical thing to assume here is that the child exited. However the current code never reports back the child error from wait nor does it try to capture the output from it. This fixes both. The cleanup error is now added to the returned error so the caller sees both.

As errors.Join is used from the std lib bump the minimum go version to 1.20.

[1] https://github.com/containers/podman/issues/18856