### PR TITLE
go.mod: bump Go version to 1.20

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,13 +13,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.18.x, 1.19.x, 1.20.x]
+        go-version: [1.20.x, 1.21.x, 1.22.x]
         criu_branch: [master, criu-dev]
 
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         # needed for codecov
         fetch-depth: 0
@@ -32,7 +32,7 @@ jobs:
         sudo make -C criu install-criu PREFIX=/usr
 
     - name: Install Go ${{ matrix.go-version }}
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go-version }}
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/checkpoint-restore/go-criu/v7
 
-go 1.18
+go 1.20
 
 require (
 	github.com/spf13/cobra v1.8.1


### PR DESCRIPTION
This pull request updates the minimum go version to 1.20. These changes are required for https://github.com/checkpoint-restore/go-criu/pull/175