### PR TITLE
ci: downgrade 'codecov-action' version to v3

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -48,7 +48,7 @@ jobs:
         sudo -E make coverage
 
     - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v3
       with:
         fail_ci_if_error: true
         file: test/.coverage/coverage.out


### PR DESCRIPTION
`codecov-action@v4` requires an [organization-level upload token](https://docs.codecov.com/docs/codecov-uploader#upload-token) instead of a single repository upload token. Thus, uploading codecov report fails with the following error when triggered by the push event of a merged pull request:

	Commit creating failed: {"detail":"You do not have permission to perform this action."}

We are temporarily downgrading from v4 to v3 until we can generate an organization-level upload token.
