### PR TITLE
ci(golangci-lint): disable gosec G115

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,3 +16,7 @@ linters:
 linters-settings:
   exhaustive:
     default-signifies-exhaustive: true
+  gosec:
+    excludes:
+      # https://github.com/securego/gosec/issues/1185
+      - G115


### PR DESCRIPTION
Changes were made to this check in v1.60.2, which introduced a lot of noise and false positives. This commit disables this for now.

Ref: https://github.com/securego/gosec/issues/1185