### PR TITLE
add(crit): other os support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,12 +9,18 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
         go-version: [1.20.x, 1.21.x, 1.22.x]
         criu_branch: [master, criu-dev]
+        exclude: # Skip duplicate CRIT build tests on macos/windows
+          - os: windows-latest
+            criu_branch: criu-dev
+          - os: macos-latest
+            criu_branch: criu-dev
 
     steps:
 
@@ -22,6 +28,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Build CRIU ${{ matrix.criu_branch }}
+      if: runner.os == 'Linux'
       run: |
         sudo apt-get install -y libprotobuf-dev libprotobuf-c-dev protobuf-c-compiler protobuf-compiler python3-protobuf libnl-3-dev libnet-dev libcap-dev curl unzip
         git clone --depth=1 --single-branch -b ${{ matrix.criu_branch }} https://github.com/checkpoint-restore/criu.git
@@ -34,17 +41,25 @@ jobs:
         go-version: ${{ matrix.go-version }}
 
     - name: Install protoc-gen-go
+      if: runner.os == 'Linux'
       run: |
         sudo env "GOBIN=/usr/bin" go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
 
     - name: Test go-criu
+      if: runner.os == 'Linux'
       run: sudo -E make test
 
     - name: Test magicgen script
+      if: runner.os == 'Linux'
       run: sudo -E make -C scripts/magic-gen test
 
     - name: Test CRIT
+      shell: bash # To support windows
       run: |
+        if [ "${{ runner.os }}" != "Linux" ]; then
+          make -C crit clean bin/crit
+          exit 0
+        fi
         if [ "${{ matrix.criu_branch }}" = "criu-dev" ]; then
           # First update protobuf. It is too old in the Ubuntu image.
           curl -Lo protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v23.4/protoc-23.4-linux-x86_64.zip

--- a/crit/mempages.go
+++ b/crit/mempages.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/checkpoint-restore/go-criu/v7/crit/images/mm"
 	"github.com/checkpoint-restore/go-criu/v7/crit/images/pagemap"
-	"golang.org/x/sys/unix"
 )
 
 var sysPageSize = os.Getpagesize()
@@ -188,7 +187,7 @@ func (mr *MemoryReader) GetShmemSize() (int64, error) {
 	mm := mmImg.Entries[0].Message.(*mm.MmEntry)
 	for _, vma := range mm.GetVmas() {
 		// Check if VMA has the MAP_SHARED flag set in its flags
-		if vma.GetFlags()&unix.MAP_SHARED != 0 {
+		if vma.GetFlags()&mapShared != 0 {
 			size += int64(vma.GetEnd() - vma.GetStart())
 		}
 	}

--- a/crit/mempages_unix.go
+++ b/crit/mempages_unix.go
@@ -1,0 +1,7 @@
+//go:build !windows
+
+package crit
+
+import "golang.org/x/sys/unix"
+
+const mapShared = unix.MAP_SHARED

--- a/crit/mempages_windows.go
+++ b/crit/mempages_windows.go
@@ -1,0 +1,5 @@
+//go:build windows
+
+package crit
+
+const mapShared = 0x1

--- a/crit/utils.go
+++ b/crit/utils.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
-	"syscall"
 
 	"github.com/checkpoint-restore/go-criu/v7/crit/images/fdinfo"
 	"github.com/checkpoint-restore/go-criu/v7/crit/images/pipe"
@@ -323,64 +322,15 @@ func getSkState(state tcpState) string {
 
 // Helper to identify address family
 func getAddressFamily(family uint32) string {
-	switch family {
-	case syscall.AF_UNIX:
-		return "UNIX"
-	case syscall.AF_NETLINK:
-		return "NETLINK"
-	case syscall.AF_BRIDGE:
-		return "BRIDGE"
-	case syscall.AF_KEY:
-		return "KEY"
-	case syscall.AF_PACKET:
-		return "PACKET"
-	case syscall.AF_INET:
-		return "IPV4"
-	case syscall.AF_INET6:
-		return "IPV6"
-	default:
-		return ""
-	}
+	return addressFamilyMap[family]
 }
 
 // Helper to identify socket type
 func getSkType(skType uint32) string {
-	switch skType {
-	case syscall.SOCK_STREAM:
-		return "STREAM"
-	case syscall.SOCK_DGRAM:
-		return "DGRAM"
-	case syscall.SOCK_SEQPACKET:
-		return "SEQPACKET"
-	case syscall.SOCK_RAW:
-		return "RAW"
-	case syscall.SOCK_RDM:
-		return "RDM"
-	case syscall.SOCK_PACKET:
-		return "PACKET"
-	default:
-		return ""
-	}
+	return socketTypeMap[skType]
 }
 
 // Helper to identify socket protocol
 func getSkProtocol(protocol uint32) string {
-	switch protocol {
-	case syscall.IPPROTO_ICMP:
-		return "ICMP"
-	case syscall.IPPROTO_ICMPV6:
-		return "ICMPV6"
-	case syscall.IPPROTO_IGMP:
-		return "IGMP"
-	case syscall.IPPROTO_RAW:
-		return "RAW"
-	case syscall.IPPROTO_TCP:
-		return "TCP"
-	case syscall.IPPROTO_UDP:
-		return "UDP"
-	case syscall.IPPROTO_UDPLITE:
-		return "UDPLITE"
-	default:
-		return ""
-	}
+	return socketProtocolMap[protocol]
 }

--- a/crit/utils_linux.go
+++ b/crit/utils_linux.go
@@ -1,0 +1,36 @@
+//go:build linux
+
+package crit
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+var (
+	addressFamilyMap = map[uint32]string{
+		unix.AF_UNIX:    "UNIX",
+		unix.AF_NETLINK: "NETLINK",
+		unix.AF_BRIDGE:  "BRIDGE",
+		unix.AF_KEY:     "KEY",
+		unix.AF_PACKET:  "PACKET",
+		unix.AF_INET:    "IPV4",
+		unix.AF_INET6:   "IPV6",
+	}
+	socketTypeMap = map[uint32]string{
+		unix.SOCK_STREAM:    "STREAM",
+		unix.SOCK_DGRAM:     "DGRAM",
+		unix.SOCK_SEQPACKET: "SEQPACKET",
+		unix.SOCK_RAW:       "RAW",
+		unix.SOCK_RDM:       "RDM",
+		unix.SOCK_PACKET:    "PACKET",
+	}
+	socketProtocolMap = map[uint32]string{
+		unix.IPPROTO_ICMP:    "ICMP",
+		unix.IPPROTO_ICMPV6:  "ICMPV6",
+		unix.IPPROTO_IGMP:    "IGMP",
+		unix.IPPROTO_RAW:     "RAW",
+		unix.IPPROTO_TCP:     "TCP",
+		unix.IPPROTO_UDP:     "UDP",
+		unix.IPPROTO_UDPLITE: "UDPLITE",
+	}
+)

--- a/crit/utils_other.go
+++ b/crit/utils_other.go
@@ -1,0 +1,32 @@
+//go:build !linux
+
+package crit
+
+var (
+	addressFamilyMap = map[uint32]string{
+		0x1:  "UNIX",    // syscall.AF_UNIX
+		0x10: "NETLINK", // syscall.AF_NETLINK
+		0x7:  "BRIDGE",  // syscall.AF_BRIDGE
+		0xf:  "KEY",     // syscall.AF_KEY
+		0x11: "PACKET",  // syscall.AF_PACKET
+		0x2:  "IPV4",    // syscall.AF_INET
+		0xa:  "IPV6",    // syscall.AF_INET6
+	}
+	socketTypeMap = map[uint32]string{
+		0x1: "STREAM",    // syscall.SOCK_STREAM
+		0x2: "DGRAM",     // syscall.SOCK_DGRAM
+		0x5: "SEQPACKET", // syscall.SOCK_SEQPACKET
+		0x3: "RAW",       // syscall.SOCK_RAW
+		0x4: "RDM",       // syscall.SOCK_RDM
+		0xa: "PACKET",    // syscall.SOCK_PACKET
+	}
+	socketProtocolMap = map[uint32]string{
+		0x1:  "ICMP",    // syscall.IPPROTO_ICMP
+		0x3a: "ICMPV6",  // syscall.IPPROTO_ICMPV6
+		0x2:  "IGMP",    // syscall.IPPROTO_IGMP
+		0xff: "RAW",     // syscall.IPPROTO_RAW
+		0x6:  "TCP",     // syscall.IPPROTO_TCP
+		0x11: "UDP",     // syscall.IPPROTO_UDP
+		0x88: "UDPLITE", // syscall.IPPROTO_UDPLITE
+	}
+)


### PR DESCRIPTION
When using CRIT on macOS, the following errors occur:
```
# github.com/checkpoint-restore/go-criu/v7/crit
../../../go/pkg/mod/github.com/checkpoint-restore/go-criu/v7@v7.2.0/crit/utils.go:329:15: undefined: syscall.AF_NETLINK
../../../go/pkg/mod/github.com/checkpoint-restore/go-criu/v7@v7.2.0/crit/utils.go:331:15: undefined: syscall.AF_BRIDGE
../../../go/pkg/mod/github.com/checkpoint-restore/go-criu/v7@v7.2.0/crit/utils.go:333:15: undefined: syscall.AF_KEY
../../../go/pkg/mod/github.com/checkpoint-restore/go-criu/v7@v7.2.0/crit/utils.go:335:15: undefined: syscall.AF_PACKET
../../../go/pkg/mod/github.com/checkpoint-restore/go-criu/v7@v7.2.0/crit/utils.go:359:15: undefined: syscall.SOCK_PACKET
../../../go/pkg/mod/github.com/checkpoint-restore/go-criu/v7@v7.2.0/crit/utils.go:381:15: undefined: syscall.IPPROTO_UDPLITE
```

I believe that CRIT can be sufficiently supported even on non-Linux platforms. Therefore, I have added the necessary support.