### PR TITLE
ci: bump actions, remove Go matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,6 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go-version: [1.21.x, 1.22.x, 1.23.x]
         criu-branch: [master, criu-dev]
         exclude: # Skip duplicate CRIT build tests on macos/windows
           - os: windows-latest
@@ -35,10 +34,10 @@ jobs:
         make -j"$(nproc)" -C criu
         sudo make -C criu install-criu PREFIX=/usr
 
-    - name: Install Go ${{ matrix.go-version }}
+    - name: Install Go
       uses: actions/setup-go@v5
       with:
-        go-version: ${{ matrix.go-version }}
+        go-version: 'stable'
 
     - name: Install protoc-gen-go
       if: runner.os == 'Linux'

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -5,7 +5,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: golangci/golangci-lint-action@v3
       with:
         version: latest
@@ -26,8 +26,8 @@ jobs:
     permissions:
       pull-requests: read
     steps:
-    - uses: actions/checkout@v3
-    - uses: dorny/paths-filter@v2
+    - uses: actions/checkout@v4
+    - uses: dorny/paths-filter@v3
       id: changes
       with:
         filters: |


### PR DESCRIPTION
The Go matrix is unnecessary, as Go provides backwards compatibility across existing APIs, and we are almost always just one version behind the latest one.