### PR TITLE
crit: humanize INETSK fields in files.img JSON output

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Build CRIU criu-dev
       run: |
         sudo apt-get update
-        sudo apt-get install -y libprotobuf-dev libprotobuf-c-dev protobuf-c-compiler protobuf-compiler python3-protobuf libnl-3-dev libnet-dev libcap-dev uuid-dev curl unzip
+        sudo apt-get install -y libprotobuf-dev libprotobuf-c-dev protobuf-c-compiler protobuf-compiler python3-protobuf libnl-3-dev libnet-dev libcap-dev uuid-dev curl unzip bats
         git clone --depth=1 --single-branch -b criu-dev https://github.com/checkpoint-restore/criu.git
         make -j"$(nproc)" -C criu
         sudo make -C criu install-criu PREFIX=/usr

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,6 +60,7 @@ jobs:
           make -C crit clean bin/crit
           exit 0
         fi
+        sudo apt-get install -y bats
         GO_BIN="$(command -v go)"
         if [ "${{ matrix.criu-branch }}" = "criu-dev" ]; then
           # First update protobuf. It is too old in the Ubuntu image.

--- a/crit/crit.go
+++ b/crit/crit.go
@@ -61,7 +61,12 @@ func New(
 // Decode loads a binary image file into a CriuImage object
 func (c *crit) Decode(entryType proto.Message) (*CriuImage, error) {
 	// Convert binary image to Go struct
-	return decodeImg(c.inputFile, entryType, c.noPayload)
+	img, err := decodeImg(c.inputFile, entryType, c.noPayload)
+	if err != nil {
+		return nil, err
+	}
+	applyHumanize(img, c.pretty)
+	return img, nil
 }
 
 // Info loads a binary image file into a CriuImage object

--- a/crit/display_files.go
+++ b/crit/display_files.go
@@ -1,11 +1,19 @@
 package crit
 
 import (
+	"bytes"
+	"encoding/binary"
 	"encoding/json"
 	"fmt"
+	"net/netip"
+	"strconv"
+	"strings"
 
 	"github.com/checkpoint-restore/go-criu/v8/crit/images/fdinfo"
+	"github.com/checkpoint-restore/go-criu/v8/crit/images/memfd"
+	"github.com/checkpoint-restore/go-criu/v8/crit/images/regfile"
 	sk_inet "github.com/checkpoint-restore/go-criu/v8/crit/images/sk-inet"
+	sk_opts "github.com/checkpoint-restore/go-criu/v8/crit/images/sk-opts"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 )
@@ -16,7 +24,7 @@ var fileEntryProtojson = protojson.MarshalOptions{
 	AllowPartial:  true,
 }
 
-// fileEntryPayloadHumanizer humanizes one FileEntry payload sub-message (reg, isk, …).
+// fileEntryPayloadHumanizer humanizes one FileEntry payload sub-message (reg, isk, ...).
 type fileEntryPayloadHumanizer func(proto.Message) ([]byte, error)
 
 type fileEntryHumanSpec struct {
@@ -28,12 +36,21 @@ type fileEntryHumanSpec struct {
 // fileEntryHumanizers maps fd_types to payload humanizers. Add an entry here when
 // implementing humanized output for a new files.img fd type.
 var fileEntryHumanizers = map[fdinfo.FdTypes]fileEntryHumanSpec{
+	fdinfo.FdTypes_REG: {
+		jsonField: "reg",
+		payload:   regFilePayload,
+		humanize:  humanizeRegPayload,
+	},
 	fdinfo.FdTypes_INETSK: {
 		jsonField: "isk",
-		payload:   func(e *fdinfo.FileEntry) proto.Message { return e.GetIsk() },
+		payload:   inetSkPayload,
 		humanize:  humanizeInetSkPayload,
 	},
-	// fdinfo.FdTypes_REG: { jsonField: "reg", payload: ..., humanize: humanizeRegPayload },
+	fdinfo.FdTypes_MEMFD: {
+		jsonField: "memfd",
+		payload:   memfdFilePayload,
+		humanize:  humanizeMemfdPayload,
+	},
 }
 
 var (
@@ -69,7 +86,51 @@ var (
 		9:  "LAST_ACK",
 		10: "LISTEN",
 	}
+	rfileFlagHumanMap = []flagHumanEntry{
+		{name: "O_WRONLY", value: 0o00000001},
+		{name: "O_RDWR", value: 0o00000002},
+		{name: "O_CREAT", value: 0o00000100},
+		{name: "O_EXCL", value: 0o00000200},
+		{name: "O_NOCTTY", value: 0o00000400},
+		{name: "O_TRUNC", value: 0o00001000},
+		{name: "O_APPEND", value: 0o00002000},
+		{name: "O_NONBLOCK", value: 0o00004000},
+		{name: "O_DSYNC", value: 0o00010000},
+		{name: "FASYNC", value: 0o00020000},
+		{name: "O_DIRECT", value: 0o00040000},
+		{name: "O_LARGEFILE", value: 0o00100000},
+		{name: "O_DIRECTORY", value: 0o00200000},
+		{name: "O_NOFOLLOW", value: 0o00400000},
+		{name: "O_NOATIME", value: 0o01000000},
+		{name: "O_CLOEXEC", value: 0o02000000},
+	}
 )
+
+type flagHumanEntry struct {
+	name  string
+	value uint64
+}
+
+func regFilePayload(entry *fdinfo.FileEntry) proto.Message {
+	if payload := entry.GetReg(); payload != nil {
+		return payload
+	}
+	return nil
+}
+
+func inetSkPayload(entry *fdinfo.FileEntry) proto.Message {
+	if payload := entry.GetIsk(); payload != nil {
+		return payload
+	}
+	return nil
+}
+
+func memfdFilePayload(entry *fdinfo.FileEntry) proto.Message {
+	if payload := entry.GetMemfd(); payload != nil {
+		return payload
+	}
+	return nil
+}
 
 // fileEntryJSON mirrors file_entry field order from fdinfo.proto.
 type fileEntryJSON struct {
@@ -97,6 +158,23 @@ type fileEntryJSON struct {
 	Pidfd json.RawMessage `json:"pidfd,omitempty"`
 }
 
+// regFileJSON mirrors reg_file_entry field order from regfile.proto.
+type regFileJSON struct {
+	Id                json.RawMessage `json:"id"`
+	Flags             json.RawMessage `json:"flags"`
+	Pos               json.RawMessage `json:"pos"`
+	Fown              json.RawMessage `json:"fown"`
+	Name              json.RawMessage `json:"name"`
+	MntId             json.RawMessage `json:"mnt_id,omitempty"`
+	Size              json.RawMessage `json:"size,omitempty"`
+	Ext               json.RawMessage `json:"ext,omitempty"`
+	Mode              json.RawMessage `json:"mode,omitempty"`
+	BuildId           json.RawMessage `json:"build_id,omitempty"`
+	Checksum          json.RawMessage `json:"checksum,omitempty"`
+	ChecksumConfig    json.RawMessage `json:"checksum_config,omitempty"`
+	ChecksumParameter json.RawMessage `json:"checksum_parameter,omitempty"`
+}
+
 // inetSkJSON mirrors inet_sk_entry field order from sk-inet.proto.
 type inetSkJSON struct {
 	Id       json.RawMessage `json:"id"`
@@ -119,6 +197,44 @@ type inetSkJSON struct {
 	NsId     json.RawMessage `json:"ns_id,omitempty"`
 	Shutdown json.RawMessage `json:"shutdown,omitempty"`
 	TcpOpts  json.RawMessage `json:"tcp_opts,omitempty"`
+}
+
+// skOptsJSON mirrors sk_opts_entry field order from sk-opts.proto.
+type skOptsJSON struct {
+	SoSndbuf     json.RawMessage `json:"so_sndbuf"`
+	SoRcvbuf     json.RawMessage `json:"so_rcvbuf"`
+	SoSndTmoSec  json.RawMessage `json:"so_snd_tmo_sec"`
+	SoSndTmoUsec json.RawMessage `json:"so_snd_tmo_usec"`
+	SoRcvTmoSec  json.RawMessage `json:"so_rcv_tmo_sec"`
+	SoRcvTmoUsec json.RawMessage `json:"so_rcv_tmo_usec"`
+	Reuseaddr    json.RawMessage `json:"reuseaddr,omitempty"`
+	SoPriority   json.RawMessage `json:"so_priority,omitempty"`
+	SoRcvlowat   json.RawMessage `json:"so_rcvlowat,omitempty"`
+	SoMark       json.RawMessage `json:"so_mark,omitempty"`
+	SoPasscred   json.RawMessage `json:"so_passcred,omitempty"`
+	SoPasssec    json.RawMessage `json:"so_passsec,omitempty"`
+	SoDontroute  json.RawMessage `json:"so_dontroute,omitempty"`
+	SoNoCheck    json.RawMessage `json:"so_no_check,omitempty"`
+	SoBoundDev   json.RawMessage `json:"so_bound_dev,omitempty"`
+	SoFilter     json.RawMessage `json:"so_filter,omitempty"`
+	SoReuseport  json.RawMessage `json:"so_reuseport,omitempty"`
+	SoBroadcast  json.RawMessage `json:"so_broadcast,omitempty"`
+	SoKeepalive  json.RawMessage `json:"so_keepalive,omitempty"`
+	TcpKeepcnt   json.RawMessage `json:"tcp_keepcnt,omitempty"`
+	TcpKeepidle  json.RawMessage `json:"tcp_keepidle,omitempty"`
+	TcpKeepintvl json.RawMessage `json:"tcp_keepintvl,omitempty"`
+	SoOobinline  json.RawMessage `json:"so_oobinline,omitempty"`
+	SoLinger     json.RawMessage `json:"so_linger,omitempty"`
+	SoBufLock    json.RawMessage `json:"so_buf_lock,omitempty"`
+}
+
+// memfdFileJSON mirrors memfd_file_entry field order from memfd.proto.
+type memfdFileJSON struct {
+	Id      json.RawMessage `json:"id"`
+	Flags   json.RawMessage `json:"flags"`
+	Pos     json.RawMessage `json:"pos"`
+	Fown    json.RawMessage `json:"fown"`
+	InodeId json.RawMessage `json:"inode_id"`
 }
 
 func marshalFileEntryHuman(msg proto.Message) ([]byte, error) {
@@ -205,6 +321,35 @@ func (fe *fileEntryJSON) setPayloadField(field string, payload json.RawMessage) 
 	return nil
 }
 
+func humanizeRegPayload(msg proto.Message) ([]byte, error) {
+	reg, ok := msg.(*regfile.RegFileEntry)
+	if !ok {
+		return nil, fmt.Errorf("humanizeRegPayload: unexpected type %T", msg)
+	}
+
+	data, err := fileEntryProtojson.Marshal(reg)
+	if err != nil {
+		return nil, err
+	}
+
+	var rf regFileJSON
+	if err := json.Unmarshal(data, &rf); err != nil {
+		return nil, err
+	}
+
+	if reg.Flags != nil {
+		rf.Flags = rawJSONString(formatFlags(uint64(reg.GetFlags()), rfileFlagHumanMap))
+	}
+	if reg.Pos != nil {
+		rf.Pos = rawJSONValue(reg.GetPos())
+	}
+	if reg.Size != nil {
+		rf.Size = rawJSONValue(reg.GetSize())
+	}
+
+	return json.Marshal(rf)
+}
+
 func humanizeInetSkPayload(msg proto.Message) ([]byte, error) {
 	isk, ok := msg.(*sk_inet.InetSkEntry)
 	if !ok {
@@ -243,8 +388,71 @@ func humanizeInetSkPayload(msg proto.Message) ([]byte, error) {
 	if addrs := ipAddrsHuman(isk.GetDstAddr()); addrs != nil {
 		sk.DstAddr = rawJSONValue(addrs)
 	}
+	if opts := isk.GetOpts(); opts != nil {
+		humanOpts, err := humanizeSkOpts(opts)
+		if err != nil {
+			return nil, err
+		}
+		sk.Opts = humanOpts
+	}
 
 	return json.Marshal(sk)
+}
+
+func humanizeSkOpts(opts *sk_opts.SkOptsEntry) (json.RawMessage, error) {
+	data, err := fileEntryProtojson.Marshal(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	var so skOptsJSON
+	if err := json.Unmarshal(data, &so); err != nil {
+		return nil, err
+	}
+
+	if opts.SoSndTmoSec != nil {
+		so.SoSndTmoSec = rawJSONValue(opts.GetSoSndTmoSec())
+	}
+	if opts.SoSndTmoUsec != nil {
+		so.SoSndTmoUsec = rawJSONValue(opts.GetSoSndTmoUsec())
+	}
+	if opts.SoRcvTmoSec != nil {
+		so.SoRcvTmoSec = rawJSONValue(opts.GetSoRcvTmoSec())
+	}
+	if opts.SoRcvTmoUsec != nil {
+		so.SoRcvTmoUsec = rawJSONValue(opts.GetSoRcvTmoUsec())
+	}
+	if len(opts.GetSoFilter()) > 0 {
+		so.SoFilter = rawJSONValue(opts.GetSoFilter())
+	}
+
+	return json.Marshal(so)
+}
+
+func humanizeMemfdPayload(msg proto.Message) ([]byte, error) {
+	m, ok := msg.(*memfd.MemfdFileEntry)
+	if !ok {
+		return nil, fmt.Errorf("humanizeMemfdPayload: unexpected type %T", msg)
+	}
+
+	data, err := fileEntryProtojson.Marshal(m)
+	if err != nil {
+		return nil, err
+	}
+
+	var mf memfdFileJSON
+	if err := json.Unmarshal(data, &mf); err != nil {
+		return nil, err
+	}
+
+	if m.Flags != nil {
+		mf.Flags = rawJSONString(formatFlags(uint64(m.GetFlags()), rfileFlagHumanMap))
+	}
+	if m.Pos != nil {
+		mf.Pos = rawJSONValue(m.GetPos())
+	}
+
+	return json.Marshal(mf)
 }
 
 func rawJSONString(s string) json.RawMessage {
@@ -262,6 +470,339 @@ func rawJSONHumanMap(m map[uint32]string, value uint32) json.RawMessage {
 		return rawJSONString(text)
 	}
 	return rawJSONValue(value)
+}
+
+func formatFlags(value uint64, flags []flagHumanEntry) string {
+	var names []string
+	for _, flag := range flags {
+		if value&flag.value != 0 {
+			names = append(names, flag.name)
+			value &^= flag.value
+		}
+	}
+	if value != 0 {
+		names = append(names, fmt.Sprintf("0x%x", value))
+	}
+	return strings.Join(names, " | ")
+}
+
+func normalizeFileEntryJSON(data []byte) ([]byte, error) {
+	var entry map[string]json.RawMessage
+	if err := json.Unmarshal(data, &entry); err != nil {
+		return nil, err
+	}
+
+	for _, field := range []string{"reg", "memfd"} {
+		if err := normalizeFileFlagsPayload(entry, field); err != nil {
+			return nil, err
+		}
+	}
+	if err := normalizeInetSkPayload(entry); err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(entry)
+}
+
+func normalizeFileFlagsPayload(entry map[string]json.RawMessage, field string) error {
+	payload, ok, err := jsonObjectField(entry, field)
+	if err != nil || !ok {
+		return err
+	}
+
+	if err := normalizeFlagField(payload, "flags", rfileFlagHumanMap); err != nil {
+		return err
+	}
+	if err := normalizeUint64Fields(payload, "pos", "size"); err != nil {
+		return err
+	}
+
+	entry[field], err = json.Marshal(payload)
+	return err
+}
+
+func normalizeInetSkPayload(entry map[string]json.RawMessage) error {
+	isk, ok, err := jsonObjectField(entry, "isk")
+	if err != nil || !ok {
+		return err
+	}
+
+	if err := normalizeHumanMapField(isk, "family", inetSkFamilyHumanMap); err != nil {
+		return err
+	}
+	if err := normalizeHumanMapField(isk, "type", inetSkTypeHumanMap); err != nil {
+		return err
+	}
+	if err := normalizeHumanMapField(isk, "proto", inetSkProtocolHumanMap); err != nil {
+		return err
+	}
+	if err := normalizeHumanMapField(isk, "state", inetSkStateHumanMap); err != nil {
+		return err
+	}
+	if err := normalizeUint32StringField(isk, "flags"); err != nil {
+		return err
+	}
+	if err := normalizeIPAddrField(isk, "src_addr"); err != nil {
+		return err
+	}
+	if err := normalizeIPAddrField(isk, "dst_addr"); err != nil {
+		return err
+	}
+
+	opts, ok, err := jsonObjectField(isk, "opts")
+	if err != nil {
+		return err
+	}
+	if ok {
+		if err := normalizeUint64Fields(opts,
+			"so_snd_tmo_sec",
+			"so_snd_tmo_usec",
+			"so_rcv_tmo_sec",
+			"so_rcv_tmo_usec",
+			"so_filter",
+		); err != nil {
+			return err
+		}
+		isk["opts"], err = json.Marshal(opts)
+		if err != nil {
+			return err
+		}
+	}
+
+	entry["isk"], err = json.Marshal(isk)
+	return err
+}
+
+func jsonObjectField(obj map[string]json.RawMessage, field string) (map[string]json.RawMessage, bool, error) {
+	data, ok := obj[field]
+	if !ok {
+		return nil, false, nil
+	}
+
+	var child map[string]json.RawMessage
+	if err := json.Unmarshal(data, &child); err != nil {
+		return nil, false, err
+	}
+	return child, true, nil
+}
+
+func normalizeFlagField(obj map[string]json.RawMessage, field string, flags []flagHumanEntry) error {
+	text, ok := jsonStringField(obj, field)
+	if !ok {
+		return nil
+	}
+
+	value, err := parseFlags(text, flags)
+	if err != nil {
+		return err
+	}
+	obj[field] = rawJSONValue(value)
+	return nil
+}
+
+func normalizeHumanMapField(obj map[string]json.RawMessage, field string, values map[uint32]string) error {
+	text, ok := jsonStringField(obj, field)
+	if !ok {
+		return nil
+	}
+
+	value, err := parseHumanMapValue(text, values)
+	if err != nil {
+		return err
+	}
+	obj[field] = rawJSONValue(value)
+	return nil
+}
+
+func normalizeUint32StringField(obj map[string]json.RawMessage, field string) error {
+	text, ok := jsonStringField(obj, field)
+	if !ok {
+		return nil
+	}
+
+	value, err := strconv.ParseUint(text, 0, 32)
+	if err != nil {
+		return err
+	}
+	obj[field] = rawJSONValue(uint32(value))
+	return nil
+}
+
+func normalizeIPAddrField(obj map[string]json.RawMessage, field string) error {
+	data, ok := obj[field]
+	if !ok {
+		return nil
+	}
+
+	if !isJSONStringArray(data) {
+		return nil
+	}
+
+	var addrs []string
+	if err := json.Unmarshal(data, &addrs); err != nil {
+		return err
+	}
+	if len(addrs) != 1 {
+		return fmt.Errorf("%s: expected one humanized IP address, got %d", field, len(addrs))
+	}
+
+	parts, err := ipParts(addrs[0])
+	if err != nil {
+		return err
+	}
+	obj[field] = rawJSONValue(parts)
+	return nil
+}
+
+func isJSONStringArray(data json.RawMessage) bool {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) < 2 || trimmed[0] != '[' {
+		return false
+	}
+	trimmed = bytes.TrimSpace(trimmed[1:])
+	return len(trimmed) > 0 && trimmed[0] == '"'
+}
+
+func normalizeUint64Fields(obj map[string]json.RawMessage, fields ...string) error {
+	for _, field := range fields {
+		data, ok := obj[field]
+		if !ok {
+			continue
+		}
+		normalized, changed, err := normalizeUint64JSON(data)
+		if err != nil {
+			return err
+		}
+		if changed {
+			obj[field] = normalized
+		}
+	}
+	return nil
+}
+
+func normalizeUint64JSON(data json.RawMessage) (json.RawMessage, bool, error) {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+
+	var value any
+	if err := decoder.Decode(&value); err != nil {
+		return nil, false, err
+	}
+
+	switch typed := value.(type) {
+	case json.Number:
+		text, err := uint64Text(typed)
+		if err != nil {
+			return nil, false, err
+		}
+		return rawJSONString(text), true, nil
+	case []any:
+		values := make([]string, 0, len(typed))
+		changed := false
+		for _, item := range typed {
+			switch item := item.(type) {
+			case json.Number:
+				text, err := uint64Text(item)
+				if err != nil {
+					return nil, false, err
+				}
+				values = append(values, text)
+				changed = true
+			case string:
+				values = append(values, item)
+			default:
+				return nil, false, fmt.Errorf("unexpected uint64 JSON value %T", item)
+			}
+		}
+		if !changed {
+			return nil, false, nil
+		}
+		return rawJSONValue(values), true, nil
+	default:
+		return nil, false, nil
+	}
+}
+
+func uint64Text(value json.Number) (string, error) {
+	if _, err := strconv.ParseUint(value.String(), 10, 64); err != nil {
+		return "", err
+	}
+	return value.String(), nil
+}
+
+func jsonStringField(obj map[string]json.RawMessage, field string) (string, bool) {
+	data, ok := obj[field]
+	if !ok {
+		return "", false
+	}
+
+	var value string
+	if err := json.Unmarshal(data, &value); err != nil {
+		return "", false
+	}
+	return value, true
+}
+
+func parseFlags(text string, flags []flagHumanEntry) (uint64, error) {
+	if text == "" {
+		return 0, nil
+	}
+
+	names := make(map[string]uint64, len(flags))
+	for _, flag := range flags {
+		names[flag.name] = flag.value
+	}
+
+	var value uint64
+	for _, part := range strings.Split(text, "|") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		if flag, ok := names[part]; ok {
+			value |= flag
+			continue
+		}
+		unknown, err := strconv.ParseUint(part, 0, 64)
+		if err != nil {
+			return 0, fmt.Errorf("unknown flag %q", part)
+		}
+		value |= unknown
+	}
+	return value, nil
+}
+
+func parseHumanMapValue(text string, values map[uint32]string) (uint32, error) {
+	for value, name := range values {
+		if text == name {
+			return value, nil
+		}
+	}
+
+	value, err := strconv.ParseUint(text, 0, 32)
+	if err != nil {
+		return 0, fmt.Errorf("unknown humanized value %q", text)
+	}
+	return uint32(value), nil
+}
+
+func ipParts(text string) ([]uint32, error) {
+	addr, err := netip.ParseAddr(text)
+	if err != nil {
+		return nil, err
+	}
+
+	if addr.Is4() {
+		ip := addr.As4()
+		return []uint32{binary.LittleEndian.Uint32(ip[:])}, nil
+	}
+
+	ip := addr.As16()
+	parts := make([]uint32, 4)
+	for i := range parts {
+		parts[i] = binary.LittleEndian.Uint32(ip[i*4:])
+	}
+	return parts, nil
 }
 
 func ipAddrsHuman(parts []uint32) []string {

--- a/crit/display_files.go
+++ b/crit/display_files.go
@@ -1,0 +1,276 @@
+package crit
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/checkpoint-restore/go-criu/v8/crit/images/fdinfo"
+	sk_inet "github.com/checkpoint-restore/go-criu/v8/crit/images/sk-inet"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+)
+
+// fileEntryProtojson is used for files.img entries before optional field patches.
+var fileEntryProtojson = protojson.MarshalOptions{
+	UseProtoNames: true,
+	AllowPartial:  true,
+}
+
+// fileEntryPayloadHumanizer humanizes one FileEntry payload sub-message (reg, isk, …).
+type fileEntryPayloadHumanizer func(proto.Message) ([]byte, error)
+
+type fileEntryHumanSpec struct {
+	jsonField string
+	payload   func(*fdinfo.FileEntry) proto.Message
+	humanize  fileEntryPayloadHumanizer
+}
+
+// fileEntryHumanizers maps fd_types to payload humanizers. Add an entry here when
+// implementing humanized output for a new files.img fd type.
+var fileEntryHumanizers = map[fdinfo.FdTypes]fileEntryHumanSpec{
+	fdinfo.FdTypes_INETSK: {
+		jsonField: "isk",
+		payload:   func(e *fdinfo.FileEntry) proto.Message { return e.GetIsk() },
+		humanize:  humanizeInetSkPayload,
+	},
+	// fdinfo.FdTypes_REG: { jsonField: "reg", payload: ..., humanize: humanizeRegPayload },
+}
+
+var (
+	inetSkFamilyHumanMap = map[uint32]string{
+		1:  "UNIX",
+		2:  "INET",
+		10: "INET6",
+		16: "NETLINK",
+		17: "PACKET",
+	}
+	inetSkTypeHumanMap = map[uint32]string{
+		1:  "STREAM",
+		2:  "DGRAM",
+		3:  "RAW",
+		5:  "SEQPACKET",
+		10: "PACKET",
+	}
+	inetSkProtocolHumanMap = map[uint32]string{
+		0:   "IP",
+		6:   "TCP",
+		17:  "UDP",
+		136: "UDPLITE",
+	}
+	inetSkStateHumanMap = map[uint32]string{
+		1:  "ESTABLISHED",
+		2:  "SYN_SENT",
+		3:  "SYN_RECV",
+		4:  "FIN_WAIT1",
+		5:  "FIN_WAIT2",
+		6:  "TIME_WAIT",
+		7:  "CLOSE",
+		8:  "CLOSE_WAIT",
+		9:  "LAST_ACK",
+		10: "LISTEN",
+	}
+)
+
+// fileEntryJSON mirrors file_entry field order from fdinfo.proto.
+type fileEntryJSON struct {
+	Type  string          `json:"type"`
+	Id    uint32          `json:"id"`
+	Reg   json.RawMessage `json:"reg,omitempty"`
+	Isk   json.RawMessage `json:"isk,omitempty"`
+	Nsf   json.RawMessage `json:"nsf,omitempty"`
+	Psk   json.RawMessage `json:"psk,omitempty"`
+	Nlsk  json.RawMessage `json:"nlsk,omitempty"`
+	Efd   json.RawMessage `json:"efd,omitempty"`
+	Epfd  json.RawMessage `json:"epfd,omitempty"`
+	Sgfd  json.RawMessage `json:"sgfd,omitempty"`
+	Tunf  json.RawMessage `json:"tunf,omitempty"`
+	Tfd   json.RawMessage `json:"tfd,omitempty"`
+	Ify   json.RawMessage `json:"ify,omitempty"`
+	Ffy   json.RawMessage `json:"ffy,omitempty"`
+	Ext   json.RawMessage `json:"ext,omitempty"`
+	Usk   json.RawMessage `json:"usk,omitempty"`
+	Fifo  json.RawMessage `json:"fifo,omitempty"`
+	Pipe  json.RawMessage `json:"pipe,omitempty"`
+	Tty   json.RawMessage `json:"tty,omitempty"`
+	Memfd json.RawMessage `json:"memfd,omitempty"`
+	Bpf   json.RawMessage `json:"bpf,omitempty"`
+	Pidfd json.RawMessage `json:"pidfd,omitempty"`
+}
+
+// inetSkJSON mirrors inet_sk_entry field order from sk-inet.proto.
+type inetSkJSON struct {
+	Id       json.RawMessage `json:"id"`
+	Ino      json.RawMessage `json:"ino"`
+	Family   json.RawMessage `json:"family,omitempty"`
+	Type     json.RawMessage `json:"type,omitempty"`
+	Proto    json.RawMessage `json:"proto,omitempty"`
+	State    json.RawMessage `json:"state,omitempty"`
+	SrcPort  json.RawMessage `json:"src_port"`
+	DstPort  json.RawMessage `json:"dst_port"`
+	Flags    json.RawMessage `json:"flags,omitempty"`
+	Backlog  json.RawMessage `json:"backlog"`
+	SrcAddr  json.RawMessage `json:"src_addr,omitempty"`
+	DstAddr  json.RawMessage `json:"dst_addr,omitempty"`
+	Fown     json.RawMessage `json:"fown,omitempty"`
+	Opts     json.RawMessage `json:"opts,omitempty"`
+	V6only   json.RawMessage `json:"v6only,omitempty"`
+	IpOpts   json.RawMessage `json:"ip_opts,omitempty"`
+	Ifname   json.RawMessage `json:"ifname,omitempty"`
+	NsId     json.RawMessage `json:"ns_id,omitempty"`
+	Shutdown json.RawMessage `json:"shutdown,omitempty"`
+	TcpOpts  json.RawMessage `json:"tcp_opts,omitempty"`
+}
+
+func marshalFileEntryHuman(msg proto.Message) ([]byte, error) {
+	entry, ok := msg.(*fdinfo.FileEntry)
+	if !ok {
+		return nil, fmt.Errorf("unexpected message type %T", msg)
+	}
+
+	data, err := fileEntryProtojson.Marshal(entry)
+	if err != nil {
+		return nil, err
+	}
+
+	spec, ok := fileEntryHumanizers[entry.GetType()]
+	if !ok {
+		return data, nil
+	}
+
+	payload := spec.payload(entry)
+	if payload == nil {
+		return data, nil
+	}
+
+	humanPayload, err := spec.humanize(payload)
+	if err != nil {
+		return nil, err
+	}
+
+	var fe fileEntryJSON
+	if err := json.Unmarshal(data, &fe); err != nil {
+		return nil, err
+	}
+	if err := fe.setPayloadField(spec.jsonField, humanPayload); err != nil {
+		return nil, err
+	}
+	return json.Marshal(fe)
+}
+
+func (fe *fileEntryJSON) setPayloadField(field string, payload json.RawMessage) error {
+	switch field {
+	case "reg":
+		fe.Reg = payload
+	case "isk":
+		fe.Isk = payload
+	case "nsf":
+		fe.Nsf = payload
+	case "psk":
+		fe.Psk = payload
+	case "nlsk":
+		fe.Nlsk = payload
+	case "efd":
+		fe.Efd = payload
+	case "epfd":
+		fe.Epfd = payload
+	case "sgfd":
+		fe.Sgfd = payload
+	case "tunf":
+		fe.Tunf = payload
+	case "tfd":
+		fe.Tfd = payload
+	case "ify":
+		fe.Ify = payload
+	case "ffy":
+		fe.Ffy = payload
+	case "ext":
+		fe.Ext = payload
+	case "usk":
+		fe.Usk = payload
+	case "fifo":
+		fe.Fifo = payload
+	case "pipe":
+		fe.Pipe = payload
+	case "tty":
+		fe.Tty = payload
+	case "memfd":
+		fe.Memfd = payload
+	case "bpf":
+		fe.Bpf = payload
+	case "pidfd":
+		fe.Pidfd = payload
+	default:
+		return fmt.Errorf("unsupported payload field %q", field)
+	}
+	return nil
+}
+
+func humanizeInetSkPayload(msg proto.Message) ([]byte, error) {
+	isk, ok := msg.(*sk_inet.InetSkEntry)
+	if !ok {
+		return nil, fmt.Errorf("humanizeInetSkPayload: unexpected type %T", msg)
+	}
+
+	data, err := fileEntryProtojson.Marshal(isk)
+	if err != nil {
+		return nil, err
+	}
+
+	var sk inetSkJSON
+	if err := json.Unmarshal(data, &sk); err != nil {
+		return nil, err
+	}
+
+	if isk.Family != nil {
+		sk.Family = rawJSONHumanMap(inetSkFamilyHumanMap, isk.GetFamily())
+	}
+	if isk.Type != nil {
+		sk.Type = rawJSONHumanMap(inetSkTypeHumanMap, isk.GetType())
+	}
+	if isk.Proto != nil {
+		sk.Proto = rawJSONHumanMap(inetSkProtocolHumanMap, isk.GetProto())
+	}
+	if isk.State != nil {
+		sk.State = rawJSONHumanMap(inetSkStateHumanMap, isk.GetState())
+	}
+	if isk.Flags != nil {
+		sk.Flags = rawJSONString(fmt.Sprintf("0x%x", isk.GetFlags()))
+	}
+
+	if addrs := ipAddrsHuman(isk.GetSrcAddr()); addrs != nil {
+		sk.SrcAddr = rawJSONValue(addrs)
+	}
+	if addrs := ipAddrsHuman(isk.GetDstAddr()); addrs != nil {
+		sk.DstAddr = rawJSONValue(addrs)
+	}
+
+	return json.Marshal(sk)
+}
+
+func rawJSONString(s string) json.RawMessage {
+	b, _ := json.Marshal(s)
+	return b
+}
+
+func rawJSONValue(v any) json.RawMessage {
+	b, _ := json.Marshal(v)
+	return b
+}
+
+func rawJSONHumanMap(m map[uint32]string, value uint32) json.RawMessage {
+	if text, ok := m[value]; ok {
+		return rawJSONString(text)
+	}
+	return rawJSONValue(value)
+}
+
+func ipAddrsHuman(parts []uint32) []string {
+	if len(parts) == 0 {
+		return nil
+	}
+	addr := processIP(parts)
+	if addr == "" {
+		return nil
+	}
+	return []string{addr}
+}

--- a/crit/display_files_test.go
+++ b/crit/display_files_test.go
@@ -3,10 +3,15 @@ package crit
 import (
 	"bytes"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/checkpoint-restore/go-criu/v8/crit/images/fdinfo"
+	"github.com/checkpoint-restore/go-criu/v8/crit/images/fown"
+	"github.com/checkpoint-restore/go-criu/v8/crit/images/memfd"
+	"github.com/checkpoint-restore/go-criu/v8/crit/images/regfile"
 	sk_inet "github.com/checkpoint-restore/go-criu/v8/crit/images/sk-inet"
+	sk_opts "github.com/checkpoint-restore/go-criu/v8/crit/images/sk-opts"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -119,6 +124,47 @@ func TestMarshalFileEntryHumanINETSKSkDictNumericFallback(t *testing.T) {
 	}
 }
 
+func TestMarshalFileEntryHumanINETSKOptsUint64Numbers(t *testing.T) {
+	isk := marshalHumanInetSk(t, &sk_inet.InetSkEntry{
+		Family: proto.Uint32(2),
+		Type:   proto.Uint32(1),
+		Proto:  proto.Uint32(6),
+		State:  proto.Uint32(7),
+		Opts: &sk_opts.SkOptsEntry{
+			SoSndbuf:     proto.Uint32(4096),
+			SoRcvbuf:     proto.Uint32(8192),
+			SoSndTmoSec:  proto.Uint64(1),
+			SoSndTmoUsec: proto.Uint64(2),
+			SoRcvTmoSec:  proto.Uint64(3),
+			SoRcvTmoUsec: proto.Uint64(4),
+			SoFilter:     []uint64{5},
+		},
+	})
+
+	opts, ok := isk["opts"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected opts object, got %#v", isk["opts"])
+	}
+
+	checks := map[string]float64{
+		"so_snd_tmo_sec":  1,
+		"so_snd_tmo_usec": 2,
+		"so_rcv_tmo_sec":  3,
+		"so_rcv_tmo_usec": 4,
+	}
+	for key, want := range checks {
+		got, ok := opts[key].(float64)
+		if !ok || got != want {
+			t.Errorf("opts.%s: want numeric %v, got %#v", key, want, opts[key])
+		}
+	}
+
+	filter, ok := opts["so_filter"].([]any)
+	if !ok || len(filter) != 1 || filter[0] != float64(5) {
+		t.Errorf("opts.so_filter: want numeric [5], got %#v", opts["so_filter"])
+	}
+}
+
 func TestMarshalFileEntryHumanINETSKPreservesFieldOrder(t *testing.T) {
 	entry := &fdinfo.FileEntry{
 		Id:   proto.Uint32(7),
@@ -187,6 +233,86 @@ func TestMarshalFileEntryHumanRegUsesProtojson(t *testing.T) {
 	}
 }
 
+func TestMarshalFileEntryHumanRegMatchesPythonPrettyFields(t *testing.T) {
+	entry := &fdinfo.FileEntry{
+		Id:   proto.Uint32(1),
+		Type: fdinfo.FdTypes_REG.Enum(),
+		Reg: &regfile.RegFileEntry{
+			Id:    proto.Uint32(1),
+			Flags: proto.Uint32(0o00100002),
+			Pos:   proto.Uint64(9),
+			Fown: &fown.FownEntry{
+				Uid:     proto.Uint32(0),
+				Euid:    proto.Uint32(0),
+				Signum:  proto.Uint32(0),
+				PidType: proto.Uint32(0),
+				Pid:     proto.Uint32(0),
+			},
+			Name: proto.String("/tmp/file"),
+			Size: proto.Uint64(123),
+		},
+	}
+
+	data, err := marshalFileEntryHuman(entry)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatal(err)
+	}
+
+	reg := got["reg"].(map[string]any)
+	if reg["flags"] != "O_RDWR | O_LARGEFILE" {
+		t.Errorf("reg.flags: want O_RDWR | O_LARGEFILE, got %#v", reg["flags"])
+	}
+	if reg["pos"] != float64(9) {
+		t.Errorf("reg.pos: want numeric 9, got %#v", reg["pos"])
+	}
+	if reg["size"] != float64(123) {
+		t.Errorf("reg.size: want numeric 123, got %#v", reg["size"])
+	}
+}
+
+func TestMarshalFileEntryHumanMemfdMatchesPythonPrettyFields(t *testing.T) {
+	entry := &fdinfo.FileEntry{
+		Id:   proto.Uint32(1),
+		Type: fdinfo.FdTypes_MEMFD.Enum(),
+		Memfd: &memfd.MemfdFileEntry{
+			Id:    proto.Uint32(1),
+			Flags: proto.Uint32(0),
+			Pos:   proto.Uint64(11),
+			Fown: &fown.FownEntry{
+				Uid:     proto.Uint32(0),
+				Euid:    proto.Uint32(0),
+				Signum:  proto.Uint32(0),
+				PidType: proto.Uint32(0),
+				Pid:     proto.Uint32(0),
+			},
+			InodeId: proto.Uint32(7),
+		},
+	}
+
+	data, err := marshalFileEntryHuman(entry)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatal(err)
+	}
+
+	memfd := got["memfd"].(map[string]any)
+	if memfd["flags"] != "" {
+		t.Errorf("memfd.flags: want empty string, got %#v", memfd["flags"])
+	}
+	if memfd["pos"] != float64(11) {
+		t.Errorf("memfd.pos: want numeric 11, got %#v", memfd["pos"])
+	}
+}
+
 func TestCriuEntryMarshalJSONHumanizeRegUsesProtojson(t *testing.T) {
 	entry := &CriuEntry{
 		Humanize: true,
@@ -238,6 +364,132 @@ func TestCriuEntryMarshalJSONHumanizeFileEntry(t *testing.T) {
 	isk := got["isk"].(map[string]any)
 	if isk["proto"] != "TCP" {
 		t.Errorf("expected humanized proto, got %v", isk["proto"])
+	}
+}
+
+func TestCriuImageUnmarshalHumanizedFilesEntry(t *testing.T) {
+	entries := []*fdinfo.FileEntry{
+		{
+			Id:   proto.Uint32(1),
+			Type: fdinfo.FdTypes_REG.Enum(),
+			Reg: &regfile.RegFileEntry{
+				Id:    proto.Uint32(1),
+				Flags: proto.Uint32(0),
+				Pos:   proto.Uint64(9),
+				Fown: &fown.FownEntry{
+					Uid:     proto.Uint32(0),
+					Euid:    proto.Uint32(0),
+					Signum:  proto.Uint32(0),
+					PidType: proto.Uint32(0),
+					Pid:     proto.Uint32(0),
+				},
+				Name: proto.String("/tmp/file"),
+				Size: proto.Uint64(123),
+			},
+		},
+		{
+			Id:   proto.Uint32(2),
+			Type: fdinfo.FdTypes_REG.Enum(),
+			Reg: &regfile.RegFileEntry{
+				Id:    proto.Uint32(2),
+				Flags: proto.Uint32(0o00100002),
+				Pos:   proto.Uint64(10),
+				Fown: &fown.FownEntry{
+					Uid:     proto.Uint32(0),
+					Euid:    proto.Uint32(0),
+					Signum:  proto.Uint32(0),
+					PidType: proto.Uint32(0),
+					Pid:     proto.Uint32(0),
+				},
+				Name: proto.String("/tmp/file2"),
+			},
+		},
+		{
+			Id:   proto.Uint32(3),
+			Type: fdinfo.FdTypes_INETSK.Enum(),
+			Isk: &sk_inet.InetSkEntry{
+				Id:      proto.Uint32(3),
+				Ino:     proto.Uint32(106886),
+				Family:  proto.Uint32(2),
+				Type:    proto.Uint32(1),
+				Proto:   proto.Uint32(6),
+				State:   proto.Uint32(7),
+				SrcPort: proto.Uint32(8880),
+				DstPort: proto.Uint32(0),
+				Flags:   proto.Uint32(2),
+				Backlog: proto.Uint32(1),
+				SrcAddr: []uint32{0x0100007f},
+				DstAddr: []uint32{0},
+				Fown: &fown.FownEntry{
+					Uid:     proto.Uint32(0),
+					Euid:    proto.Uint32(0),
+					Signum:  proto.Uint32(0),
+					PidType: proto.Uint32(0),
+					Pid:     proto.Uint32(0),
+				},
+				Opts: &sk_opts.SkOptsEntry{
+					SoSndbuf:     proto.Uint32(4096),
+					SoRcvbuf:     proto.Uint32(8192),
+					SoSndTmoSec:  proto.Uint64(1),
+					SoSndTmoUsec: proto.Uint64(2),
+					SoRcvTmoSec:  proto.Uint64(3),
+					SoRcvTmoUsec: proto.Uint64(4),
+					SoFilter:     []uint64{5},
+				},
+			},
+		},
+	}
+
+	rawEntries := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		data, err := marshalFileEntryHuman(entry)
+		if err != nil {
+			t.Fatal(err)
+		}
+		rawEntries = append(rawEntries, string(data))
+	}
+
+	data := []byte(`{"magic":"FILES","entries":[` + strings.Join(rawEntries, ",") + `]}`)
+	img := CriuImage{EntryType: &fdinfo.FileEntry{}}
+	if err := json.Unmarshal(data, &img); err != nil {
+		t.Fatal(err)
+	}
+
+	regZero := img.Entries[0].Message.(*fdinfo.FileEntry).GetReg()
+	if regZero.GetFlags() != 0 || regZero.GetPos() != 9 || regZero.GetSize() != 123 {
+		t.Fatalf("unexpected zero-flag reg entry: flags=%#o pos=%d size=%d", regZero.GetFlags(), regZero.GetPos(), regZero.GetSize())
+	}
+
+	regNames := img.Entries[1].Message.(*fdinfo.FileEntry).GetReg()
+	if regNames.GetFlags() != 0o00100002 {
+		t.Fatalf("reg flags: want %#o, got %#o", 0o00100002, regNames.GetFlags())
+	}
+
+	isk := img.Entries[2].Message.(*fdinfo.FileEntry).GetIsk()
+	checks := map[string]uint32{
+		"family": isk.GetFamily(),
+		"type":   isk.GetType(),
+		"proto":  isk.GetProto(),
+		"state":  isk.GetState(),
+		"flags":  isk.GetFlags(),
+	}
+	wants := map[string]uint32{
+		"family": 2,
+		"type":   1,
+		"proto":  6,
+		"state":  7,
+		"flags":  2,
+	}
+	for field, got := range checks {
+		if got != wants[field] {
+			t.Fatalf("isk.%s: want %d, got %d", field, wants[field], got)
+		}
+	}
+	if got := processIP(isk.GetSrcAddr()); got != "127.0.0.1" {
+		t.Fatalf("isk.src_addr: want 127.0.0.1, got %s", got)
+	}
+	if got := isk.GetOpts().GetSoFilter(); len(got) != 1 || got[0] != 5 {
+		t.Fatalf("opts.so_filter: want [5], got %#v", got)
 	}
 }
 

--- a/crit/display_files_test.go
+++ b/crit/display_files_test.go
@@ -1,0 +1,268 @@
+package crit
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/checkpoint-restore/go-criu/v8/crit/images/fdinfo"
+	sk_inet "github.com/checkpoint-restore/go-criu/v8/crit/images/sk-inet"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestMarshalFileEntryHumanINETSK(t *testing.T) {
+	entry := &fdinfo.FileEntry{
+		Id:   proto.Uint32(36),
+		Type: fdinfo.FdTypes_INETSK.Enum(),
+		Isk: &sk_inet.InetSkEntry{
+			Id:      proto.Uint32(36),
+			Ino:     proto.Uint32(106886),
+			Family:  proto.Uint32(2), // AF_INET
+			Type:    proto.Uint32(1), // SOCK_STREAM
+			Proto:   proto.Uint32(6), // TCP
+			State:   proto.Uint32(7), // TCP_CLOSE
+			SrcPort: proto.Uint32(0),
+			DstPort: proto.Uint32(0),
+			Flags:   proto.Uint32(2),
+			Backlog: proto.Uint32(0),
+			SrcAddr: []uint32{0},
+			DstAddr: []uint32{0},
+		},
+	}
+
+	data, err := marshalFileEntryHuman(entry)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got["type"] != "INETSK" {
+		t.Fatalf("expected INETSK entry, got %#v", got["type"])
+	}
+
+	isk, ok := got["isk"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected isk object, got %#v", got["isk"])
+	}
+
+	checks := map[string]any{
+		"family":   "INET",
+		"type":     "STREAM",
+		"proto":    "TCP",
+		"state":    "CLOSE",
+		"flags":    "0x2",
+		"src_port": float64(0),
+		"dst_port": float64(0),
+	}
+	for key, want := range checks {
+		if isk[key] != want {
+			t.Errorf("isk.%s: want %v, got %v", key, want, isk[key])
+		}
+	}
+	if _, ok := isk["fown"]; ok {
+		t.Error("did not expect fown in minimal test fixture")
+	}
+
+	srcAddr, ok := isk["src_addr"].([]any)
+	if !ok || len(srcAddr) != 1 || srcAddr[0] != "0.0.0.0" {
+		t.Errorf("isk.src_addr: want [0.0.0.0], got %v", isk["src_addr"])
+	}
+	dstAddr, ok := isk["dst_addr"].([]any)
+	if !ok || len(dstAddr) != 1 || dstAddr[0] != "0.0.0.0" {
+		t.Errorf("isk.dst_addr: want [0.0.0.0], got %v", isk["dst_addr"])
+	}
+}
+
+func TestMarshalFileEntryHumanINETSKUsesPythonSkDictNames(t *testing.T) {
+	isk := marshalHumanInetSk(t, &sk_inet.InetSkEntry{
+		Family: proto.Uint32(2),
+		Type:   proto.Uint32(1),
+		Proto:  proto.Uint32(0),
+		State:  proto.Uint32(3),
+	})
+
+	checks := map[string]any{
+		"family": "INET",
+		"type":   "STREAM",
+		"proto":  "IP",
+		"state":  "SYN_RECV",
+	}
+	for key, want := range checks {
+		if isk[key] != want {
+			t.Errorf("isk.%s: want %v, got %v", key, want, isk[key])
+		}
+	}
+}
+
+func TestMarshalFileEntryHumanINETSKSkDictNumericFallback(t *testing.T) {
+	isk := marshalHumanInetSk(t, &sk_inet.InetSkEntry{
+		Family: proto.Uint32(42),
+		Type:   proto.Uint32(4),
+		Proto:  proto.Uint32(1),
+		State:  proto.Uint32(11),
+	})
+
+	checks := map[string]float64{
+		"family": 42,
+		"type":   4,
+		"proto":  1,
+		"state":  11,
+	}
+	for key, want := range checks {
+		got, ok := isk[key].(float64)
+		if !ok || got != want {
+			t.Errorf("isk.%s: want numeric %v, got %#v", key, want, isk[key])
+		}
+	}
+}
+
+func TestMarshalFileEntryHumanINETSKPreservesFieldOrder(t *testing.T) {
+	entry := &fdinfo.FileEntry{
+		Id:   proto.Uint32(7),
+		Type: fdinfo.FdTypes_INETSK.Enum(),
+		Isk: &sk_inet.InetSkEntry{
+			Id:      proto.Uint32(7),
+			Ino:     proto.Uint32(106886),
+			Family:  proto.Uint32(2),
+			Type:    proto.Uint32(1),
+			Proto:   proto.Uint32(6),
+			State:   proto.Uint32(7),
+			SrcPort: proto.Uint32(8880),
+			DstPort: proto.Uint32(0),
+			Flags:   proto.Uint32(2),
+			Backlog: proto.Uint32(1),
+			SrcAddr: []uint32{0},
+			DstAddr: []uint32{0},
+		},
+	}
+
+	data, err := marshalFileEntryHuman(entry)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	typeIdx := bytes.Index(data, []byte(`"type"`))
+	idIdx := bytes.Index(data, []byte(`"id"`))
+	if typeIdx < 0 || idIdx < 0 || typeIdx >= idIdx {
+		t.Fatalf("expected entry type before id, got %s", data)
+	}
+
+	iskIdx := bytes.Index(data, []byte(`"isk"`))
+	iskSection := data[iskIdx:]
+	idInIsk := bytes.Index(iskSection, []byte(`"id"`))
+	inoInIsk := bytes.Index(iskSection, []byte(`"ino"`))
+	familyInIsk := bytes.Index(iskSection, []byte(`"family"`))
+	backlogInIsk := bytes.Index(iskSection, []byte(`"backlog"`))
+	if idInIsk < 0 || inoInIsk < 0 || familyInIsk < 0 || backlogInIsk < 0 {
+		t.Fatalf("missing expected isk fields in %s", iskSection)
+	}
+	if idInIsk >= inoInIsk || inoInIsk >= familyInIsk || familyInIsk >= backlogInIsk {
+		t.Fatalf("expected proto field order in isk, got %s", iskSection)
+	}
+}
+
+func TestMarshalFileEntryHumanRegUsesProtojson(t *testing.T) {
+	entry := &fdinfo.FileEntry{
+		Id:   proto.Uint32(1),
+		Type: fdinfo.FdTypes_REG.Enum(),
+	}
+
+	data, err := marshalFileEntryHuman(entry)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got["type"] != "REG" {
+		t.Fatalf("expected REG entry, got %#v", got["type"])
+	}
+	if _, ok := got["reg"]; ok {
+		t.Fatalf("did not expect reg field without reg payload, got %#v", got["reg"])
+	}
+}
+
+func TestCriuEntryMarshalJSONHumanizeRegUsesProtojson(t *testing.T) {
+	entry := &CriuEntry{
+		Humanize: true,
+		Message: &fdinfo.FileEntry{
+			Id:   proto.Uint32(1),
+			Type: fdinfo.FdTypes_REG.Enum(),
+		},
+	}
+
+	data, err := entry.MarshalJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := got["reg"]; ok {
+		t.Fatalf("did not expect reg field for entry without reg payload, got %#v", got["reg"])
+	}
+}
+
+func TestCriuEntryMarshalJSONHumanizeFileEntry(t *testing.T) {
+	entry := &CriuEntry{
+		Humanize: true,
+		Message: &fdinfo.FileEntry{
+			Id:   proto.Uint32(1),
+			Type: fdinfo.FdTypes_INETSK.Enum(),
+			Isk: &sk_inet.InetSkEntry{
+				Family: proto.Uint32(2),
+				Type:   proto.Uint32(1),
+				Proto:  proto.Uint32(6),
+				State:  proto.Uint32(7),
+			},
+		},
+	}
+
+	data, err := entry.MarshalJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatal(err)
+	}
+
+	isk := got["isk"].(map[string]any)
+	if isk["proto"] != "TCP" {
+		t.Errorf("expected humanized proto, got %v", isk["proto"])
+	}
+}
+
+func marshalHumanInetSk(t *testing.T, isk *sk_inet.InetSkEntry) map[string]any {
+	t.Helper()
+
+	entry := &fdinfo.FileEntry{
+		Id:   proto.Uint32(1),
+		Type: fdinfo.FdTypes_INETSK.Enum(),
+		Isk:  isk,
+	}
+
+	data, err := marshalFileEntryHuman(entry)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatal(err)
+	}
+
+	iskJSON, ok := got["isk"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected isk object, got %#v", got["isk"])
+	}
+	return iskJSON
+}

--- a/crit/image.go
+++ b/crit/image.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/checkpoint-restore/go-criu/v8/crit/images/fdinfo"
 	ghost_file "github.com/checkpoint-restore/go-criu/v8/crit/images/ghost-file"
 	"github.com/checkpoint-restore/go-criu/v8/crit/images/pagemap"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -21,7 +22,8 @@ type CriuImage struct {
 // CriuEntry represents a single entry in an image
 type CriuEntry struct {
 	proto.Message
-	Extra string
+	Extra    string
+	Humanize bool `json:"-"`
 }
 
 // MarshalJSON is the marshaler for CriuEntry.
@@ -34,16 +36,34 @@ func (c *CriuEntry) MarshalJSON() ([]byte, error) {
 		return []byte(fmt.Sprint(`{"count":"`, c.Extra, `"}`)), nil
 	}
 
+	if c.Humanize {
+		if fe, ok := c.Message.(*fdinfo.FileEntry); ok {
+			data, err := marshalFileEntryHuman(fe)
+			if err != nil {
+				return nil, err
+			}
+			if c.Extra != "" {
+				return appendExtraJSON(data, c.Extra)
+			}
+			return data, nil
+		}
+	}
+
 	data, err := protojson.MarshalOptions{UseProtoNames: true}.Marshal(c.Message)
 	if err != nil {
 		return nil, err
 	}
 	// Append extra
 	if c.Extra != "" {
-		extraString := fmt.Sprint(`"extra":"`, c.Extra, `"}`)
-		data[len(data)-1] = byte(',')
-		data = append(data, []byte(extraString)...)
+		return appendExtraJSON(data, c.Extra)
 	}
+	return data, nil
+}
+
+func appendExtraJSON(data []byte, extra string) ([]byte, error) {
+	extraString := fmt.Sprint(`"extra":"`, extra, `"}`)
+	data[len(data)-1] = byte(',')
+	data = append(data, []byte(extraString)...)
 	return data, nil
 }
 
@@ -161,4 +181,14 @@ func unmarshalPagemap(imgData *jsonImage, img *CriuImage) error {
 	}
 
 	return nil
+}
+
+// Helper to enable humanized output for image entries
+func applyHumanize(img *CriuImage, humanize bool) {
+	if img == nil || !humanize {
+		return
+	}
+	for _, entry := range img.Entries {
+		entry.Humanize = true
+	}
 }

--- a/crit/image.go
+++ b/crit/image.go
@@ -123,6 +123,13 @@ func unmarshalDefault(imgData *jsonImage, img *CriuImage) error {
 		// Create proto struct to hold payload
 		payload := proto.Clone(img.EntryType)
 		jsonPayload, extraPayload := splitJSONData(data)
+		if img.Magic == "FILES" {
+			var err error
+			jsonPayload, err = normalizeFileEntryJSON(jsonPayload)
+			if err != nil {
+				return err
+			}
+		}
 		// Handle proto data
 		if err := protojson.Unmarshal(jsonPayload, payload); err != nil {
 			return err

--- a/crit/utils.go
+++ b/crit/utils.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"net/netip"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -275,11 +276,11 @@ func processIP(parts []uint32) string {
 	}
 	// IPv6
 	if len(parts) == 4 {
-		ip := make(net.IP, net.IPv6len)
-		for _, part := range parts {
-			binary.LittleEndian.PutUint32(ip, part)
+		var ip [net.IPv6len]byte
+		for i, part := range parts {
+			binary.LittleEndian.PutUint32(ip[i*4:], part)
 		}
-		return ip.String()
+		return netip.AddrFrom16(ip).String()
 	}
 	// Invalid
 	return ""
@@ -307,9 +308,9 @@ const (
 var states = map[tcpState]string{
 	tcpEstablished: "ESTABLISHED",
 	tcpSynSent:     "SYN_SENT",
-	tcpSynReceived: "SYN_RECEIVED",
-	tcpFinWait1:    "FIN_WAIT_1",
-	tcpFinWait2:    "FIN_WAIT_2",
+	tcpSynReceived: "SYN_RECV",
+	tcpFinWait1:    "FIN_WAIT1",
+	tcpFinWait2:    "FIN_WAIT2",
 	tcpTimeWait:    "TIME_WAIT",
 	tcpClose:       "CLOSE",
 	tcpCloseWait:   "CLOSE_WAIT",
@@ -324,20 +325,33 @@ func getSkState(state tcpState) string {
 	if stateName, ok := states[state]; ok {
 		return stateName
 	}
-	return ""
+	if state == 0 {
+		return ""
+	}
+	return strconv.FormatUint(uint64(state), 10)
+}
+
+func socketMapName(m map[uint32]string, value uint32) string {
+	if name, ok := m[value]; ok {
+		return name
+	}
+	if value == 0 {
+		return ""
+	}
+	return strconv.FormatUint(uint64(value), 10)
 }
 
 // Helper to identify address family
 func getAddressFamily(family uint32) string {
-	return addressFamilyMap[family]
+	return socketMapName(addressFamilyMap, family)
 }
 
 // Helper to identify socket type
 func getSkType(skType uint32) string {
-	return socketTypeMap[skType]
+	return socketMapName(socketTypeMap, skType)
 }
 
 // Helper to identify socket protocol
 func getSkProtocol(protocol uint32) string {
-	return socketProtocolMap[protocol]
+	return socketMapName(socketProtocolMap, protocol)
 }

--- a/crit/utils_linux.go
+++ b/crit/utils_linux.go
@@ -25,6 +25,7 @@ var (
 		unix.SOCK_PACKET:    "PACKET",
 	}
 	socketProtocolMap = map[uint32]string{
+		unix.IPPROTO_IP:      "IP",
 		unix.IPPROTO_ICMP:    "ICMP",
 		unix.IPPROTO_ICMPV6:  "ICMPV6",
 		unix.IPPROTO_IGMP:    "IGMP",

--- a/crit/utils_other.go
+++ b/crit/utils_other.go
@@ -21,6 +21,7 @@ var (
 		0xa: "PACKET",    // syscall.SOCK_PACKET
 	}
 	socketProtocolMap = map[uint32]string{
+		0x0:  "IP",      // syscall.IPPROTO_IP
 		0x1:  "ICMP",    // syscall.IPPROTO_ICMP
 		0x3a: "ICMPV6",  // syscall.IPPROTO_ICMPV6
 		0x2:  "IGMP",    // syscall.IPPROTO_IGMP

--- a/crit/utils_test.go
+++ b/crit/utils_test.go
@@ -71,13 +71,38 @@ func TestProcessIP(t *testing.T) {
 		{[]uint32{0}, "0.0.0.0"},
 		{[]uint32{16777343}, "127.0.0.1"},
 		{[]uint32{0, 0, 0, 0}, "::"},
-		{[]uint32{0, 0, 4294901760, 16777343}, "7f00:1::"},
+		{[]uint32{0, 0, 4294901760, 16777343}, "::ffff:127.0.0.1"},
+		{[]uint32{33022, 0, 0, 16777216}, "fe80::1"},
 	}
 
 	for _, test := range tests {
 		got := processIP(test.input)
 		if got != test.want {
 			t.Errorf("want: %s, got: %s", test.want, got)
+		}
+	}
+}
+
+func TestSocketHumanNames(t *testing.T) {
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"syn received", getSkState(tcpSynReceived), "SYN_RECV"},
+		{"fin wait 1", getSkState(tcpFinWait1), "FIN_WAIT1"},
+		{"fin wait 2", getSkState(tcpFinWait2), "FIN_WAIT2"},
+		{"ip protocol", getSkProtocol(0), "IP"},
+		{"unknown family", getAddressFamily(42), "42"},
+		{"unknown type", getSkType(42), "42"},
+		{"unknown protocol", getSkProtocol(42), "42"},
+		{"unknown state", getSkState(tcpState(42)), "42"},
+		{"zero state", getSkState(0), ""},
+	}
+
+	for _, test := range tests {
+		if test.got != test.want {
+			t.Errorf("%s: want %q, got %q", test.name, test.want, test.got)
 		}
 	}
 }

--- a/test/crit/Makefile
+++ b/test/crit/Makefile
@@ -1,5 +1,7 @@
 GO ?= go
+CC ?= gcc
 CRIU ?= criu
+BATS ?= bats
 
 all: integration-test e2e-test clean
 
@@ -7,9 +9,13 @@ integration-test: test-imgs crit-test
 	@echo "Running integration test"
 	@./crit-test
 
-e2e-test: ../../crit/bin/crit test-imgs crit-test.sh
+e2e-test: ../../crit/bin/crit test-imgs crit-test.sh bats-test
 	@echo "Running E2E test"
 	@./crit-test.sh
+
+bats-test: ../../crit/bin/crit test-imgs
+	@echo "Running bats tests"
+	@$(BATS) humanize.bats
 
 # gen_mmapper_imgs generates CRIU images for mmapper process.
 # Parameters:
@@ -25,13 +31,19 @@ define gen_mmapper_imgs
 	$(CRIU) dump -v4 -o dump.log -D $(MM_DIR) -t $(MM_PID)
 endef
 
-test-imgs: ../loop/loop ../mmapper/mmapper
+test-imgs: ../loop/loop ../mmapper/mmapper inetsk_sleeper/inetsk_sleeper
 	$(eval LOOP_PID := $(shell ../loop/loop))
 	$(eval LOOP_DIR := $@/loop)
 	mkdir -p ${LOOP_DIR}
 	cp /proc/${LOOP_PID}/environ ${LOOP_DIR}
 	cp /proc/${LOOP_PID}/cmdline ${LOOP_DIR}
 	$(CRIU) dump -v4 -o dump.log -D ${LOOP_DIR} -t $(LOOP_PID)
+
+	$(eval INETSK_PID := $(shell ./inetsk_sleeper/inetsk_sleeper))
+	$(eval INETSK_DIR := $@/inetsk)
+	mkdir -p ${INETSK_DIR}
+	$(CRIU) dump -v4 -o dump.log -D ${INETSK_DIR} -t $(INETSK_PID)
+	kill -9 $(INETSK_PID) 2>/dev/null || true
 
 	# Generate mmapper CRIU images for different memory mapping scenarios.
 	# gen_mmapper_imgs <memory size> <mmap flags> <images dir>
@@ -57,10 +69,14 @@ test-imgs: ../loop/loop ../mmapper/mmapper
 ../mmapper/mmapper:
 	$(MAKE) -C ../mmapper
 
+inetsk_sleeper/inetsk_sleeper:
+	$(MAKE) -C inetsk_sleeper
+
 crit-test: main.go
 	$(GO) build -v -o $@ $^
 
 clean:
 	@rm -rf test-imgs crit-test /tmp/mmapper-*.log
+	$(MAKE) -C inetsk_sleeper clean
 
-.PHONY: all test integration-test e2e-test clean
+.PHONY: all test integration-test e2e-test bats-test clean

--- a/test/crit/humanize.bats
+++ b/test/crit/humanize.bats
@@ -1,0 +1,68 @@
+#!/usr/bin/env bats
+
+# shellcheck disable=SC2030,SC2031
+# SC2030/SC2031: PATH and test paths are intentionally local to each test file.
+
+CRIT=""
+FILES_IMG=""
+PRETTY_JSON=""
+RAW_JSON=""
+
+setup() {
+	# BATS_TEST_DIRNAME is set by bats to the directory containing this file.
+	CRIT="${BATS_TEST_DIRNAME}/../../crit/bin/crit"
+	FILES_IMG="${BATS_TEST_DIRNAME}/test-imgs/inetsk/files.img"
+
+	if [[ ! -x "$CRIT" ]]; then
+		skip "crit binary not found; run 'make -C crit bin/crit'"
+	fi
+	if [[ ! -f "$FILES_IMG" ]]; then
+		skip "checkpoint images not found; run 'make -C test/crit test-imgs'"
+	fi
+
+	PRETTY_JSON="$(mktemp)"
+	RAW_JSON="$(mktemp)"
+}
+
+teardown() {
+	[[ -n "$PRETTY_JSON" && -f "$PRETTY_JSON" ]] && rm -f "$PRETTY_JSON"
+	[[ -n "$RAW_JSON" && -f "$RAW_JSON" ]] && rm -f "$RAW_JSON"
+}
+
+@test "crit show humanizes INETSK fields in files.img" {
+	run "$CRIT" show "$FILES_IMG"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *'"type": "INETSK"'* ]]
+	[[ "$output" == *'"family": "INET"'* ]]
+	[[ "$output" == *'"type": "STREAM"'* ]]
+	[[ "$output" == *'"proto": "TCP"'* ]]
+	[[ "$output" == *'"src_addr": ['*'"0.0.0.0"'* ]]
+}
+
+@test "crit decode --pretty humanizes INETSK fields in files.img" {
+	run "$CRIT" decode -i "$FILES_IMG" --pretty
+	[ "$status" -eq 0 ]
+	[[ "$output" == *'"proto": "TCP"'* ]]
+	[[ "$output" == *'"family": "INET"'* ]]
+	[[ "$output" != *'"proto": 6'* ]]
+}
+
+@test "crit decode without --pretty keeps numeric INETSK fields" {
+	run "$CRIT" decode -i "$FILES_IMG"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *'"proto":6'* ]]
+	[[ "$output" != *'"proto":"TCP"'* ]]
+}
+
+@test "humanized show proto matches crit x sk protocol field" {
+	run "$CRIT" show "$FILES_IMG"
+	[ "$status" -eq 0 ]
+	pretty_show="$output"
+
+	run "$CRIT" x "${BATS_TEST_DIRNAME}/test-imgs/inetsk" sk
+	[ "$status" -eq 0 ]
+
+	# files.img uses "proto"; crit x sk uses "protocol" (same helper underneath).
+	[[ "$pretty_show" == *'"proto": "TCP"'* ]]
+	[[ "$output" == *'"protocol": "TCP"'* ]]
+}

--- a/test/crit/inetsk_sleeper/Makefile
+++ b/test/crit/inetsk_sleeper/Makefile
@@ -1,0 +1,9 @@
+CC ?= gcc
+
+inetsk_sleeper: inetsk_sleeper.c
+	$(CC) $^ -o $@
+
+clean:
+	@rm -f inetsk_sleeper
+
+.PHONY: clean

--- a/test/crit/inetsk_sleeper/inetsk_sleeper.c
+++ b/test/crit/inetsk_sleeper/inetsk_sleeper.c
@@ -1,0 +1,92 @@
+#define _GNU_SOURCE
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+/*
+ * Bind a TCP listen socket and sleep in a daemonized child. The parent
+ * prints the child PID and exits, and the child closes its stdio, so that
+ * $(shell ...) in the Makefile gets EOF and returns immediately instead of
+ * blocking on the sleeping process. Used to produce files.img entries with
+ * INETSK for crit humanize integration tests.
+ */
+int main(void)
+{
+	pid_t pid;
+	int res = EXIT_FAILURE;
+	int start_pipe[2];
+
+	if (pipe(start_pipe)) {
+		perror("pipe");
+		return 1;
+	}
+
+	pid = fork();
+	if (pid < 0) {
+		perror("fork");
+		return 1;
+	}
+
+	if (pid == 0) {
+		int fd;
+		struct sockaddr_in addr = { 0 };
+
+		close(start_pipe[0]);
+
+		if (setsid() < 0) {
+			perror("setsid");
+			goto child_out;
+		}
+
+		fd = socket(AF_INET, SOCK_STREAM, 0);
+		if (fd < 0) {
+			perror("socket");
+			goto child_out;
+		}
+
+		addr.sin_family = AF_INET;
+		addr.sin_addr.s_addr = htonl(INADDR_ANY);
+		addr.sin_port = htons(0);
+
+		if (bind(fd, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+			perror("bind");
+			goto child_out;
+		}
+		if (listen(fd, 1) < 0) {
+			perror("listen");
+			goto child_out;
+		}
+
+		close(STDIN_FILENO);
+		close(STDOUT_FILENO);
+		close(STDERR_FILENO);
+
+		res = EXIT_SUCCESS;
+		if (write(start_pipe[1], &res, sizeof(res)) != sizeof(res))
+			_exit(1);
+		close(start_pipe[1]);
+
+		while (1)
+			sleep(3600);
+
+	child_out:
+		if (write(start_pipe[1], &res, sizeof(res)) != sizeof(res))
+			_exit(1);
+		close(start_pipe[1]);
+		_exit(1);
+	}
+
+	close(start_pipe[1]);
+	if (read(start_pipe[0], &res, sizeof(res)) != sizeof(res))
+		res = EXIT_FAILURE;
+	close(start_pipe[0]);
+
+	if (res == EXIT_SUCCESS)
+		printf("%d\n", pid);
+
+	return res;
+}


### PR DESCRIPTION
## Summary
- When `crit decode --pretty` or `crit show` decodes `files.img`, INET socket (`FdTypes_INETSK`) entries now print human-readable metadata instead of raw protobuf integers.
- Reuses existing helpers from `crit x sk` (`processIP`, `getSkState`, `getAddressFamily`, etc.).
- Adds unit tests for the humanized JSON path (`display_files_test.go`).
Fixes the display gap described in #144 for INET sockets. Example:

| Field | Before | After |
|-------|--------|-------|
| family | `2` | `"INET"` |
| proto | `6` | `"TCP"` |
| state | `7` | `"CLOSE"` |
| src_addr | `[0]` | `["0.0.0.0"]` |
| flags | `2` | `"0x2"` |

## Implementation notes
- `crit.Decode()` calls `applyHumanize()` when `pretty` is true (`crit show` / `crit decode --pretty`).
- `CriuEntry.MarshalJSON()` routes `*fdinfo.FileEntry` through `marshalFileEntryHuman()` when `Humanize` is set.
- Other entry types and non-pretty decode are unchanged (still use `protojson`).
- `crit encode` is unchanged; humanized JSON is output-only and not intended for round-trip encode yet.
## Scope
First slice of #144: **INETSK entries in `files.img` only**. UNIXSK, reg files, and other fd types can follow in separate PRs.