### PR TITLE
crit: find pattern matches across memory chunk boundaries

### DIFF
--- a/crit/mempages.go
+++ b/crit/mempages.go
@@ -539,7 +539,15 @@ func (mr *MemoryReader) SearchPattern(pattern string, escapeRegExpCharacters boo
 		return nil, err
 	}
 	literalPattern, literalOnly := regexPattern.LiteralPrefix()
+	needsStreaming := !literalOnly || len(literalPattern) == 0
 	var patternTable []int
+	var streamPatterns *streamingRegexps
+	if needsStreaming {
+		streamPatterns, err = compileStreamingRegexps(pattern)
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	var results []PatternMatch
 
@@ -548,6 +556,10 @@ func (mr *MemoryReader) SearchPattern(pattern string, escapeRegExpCharacters boo
 		return nil, err
 	}
 	defer func() { _ = f.Close() }()
+	var streamReader *memoryRuneReader
+	if needsStreaming {
+		streamReader = newMemoryRuneReader(f, chunkSize)
+	}
 
 	for _, entry := range mr.pagemapEntries {
 		startAddr := entry.GetVaddr()
@@ -562,19 +574,15 @@ func (mr *MemoryReader) SearchPattern(pattern string, escapeRegExpCharacters boo
 			initialOffset += e.GetNrPages() * uint64(mr.pageSize)
 		}
 
-		if literalOnly && len(literalPattern) > 0 {
-			if patternTable == nil && uint64(len(literalPattern)) <= entrySize {
-				patternTable = literalFailureTable(literalPattern)
-			}
-			matches, err := searchLiteralPattern(
+		if needsStreaming {
+			matches, err := searchPatternStream(
 				f,
-				literalPattern,
-				patternTable,
+				streamPatterns,
+				streamReader,
 				initialOffset,
 				startAddr,
 				entrySize,
 				context,
-				chunkSize,
 			)
 			if err != nil {
 				return nil, err
@@ -582,43 +590,24 @@ func (mr *MemoryReader) SearchPattern(pattern string, escapeRegExpCharacters boo
 			results = append(results, matches...)
 			continue
 		}
-		for offset := uint64(0); offset < entrySize; offset += uint64(chunkSize) {
-			readSize := chunkSize
-			if entrySize-offset < uint64(chunkSize) {
-				readSize = int(entrySize - offset)
-			}
 
-			buff := make([]byte, readSize)
-			if err := readMemoryAt(f, buff, initialOffset, offset); err != nil {
-				return nil, err
-			}
-
-			// Replace non-printable ASCII characters in the buffer with a question mark (0x3f) to prevent unexpected behavior
-			// during regex matching. Non-printable characters might cause incorrect interpretation or premature
-			// termination of strings, leading to inaccuracies in pattern matching.
-			sanitizeMemory(buff)
-
-			indexes := regexPattern.FindAllIndex(buff, -1)
-			for _, index := range indexes {
-				matchStart := offset + uint64(index[0])
-				matchEnd := offset + uint64(index[1])
-				match, err := readPatternMatch(
-					f,
-					initialOffset,
-					startAddr,
-					entrySize,
-					matchStart,
-					matchEnd,
-					context,
-					offset,
-					buff,
-				)
-				if err != nil {
-					return nil, err
-				}
-				results = append(results, match)
-			}
+		if patternTable == nil && uint64(len(literalPattern)) <= entrySize {
+			patternTable = literalFailureTable(literalPattern)
 		}
+		matches, err := searchLiteralPattern(
+			f,
+			literalPattern,
+			patternTable,
+			initialOffset,
+			startAddr,
+			entrySize,
+			context,
+			chunkSize,
+		)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, matches...)
 	}
 
 	return results, nil

--- a/crit/mempages.go
+++ b/crit/mempages.go
@@ -277,6 +277,29 @@ func (r *memoryRuneReader) ReadRune() (rune, int, error) {
 	return rune(b), 1, nil
 }
 
+type streamingRegexps struct {
+	initial      *regexp.Regexp
+	continuation *regexp.Regexp
+}
+
+func compileStreamingRegexps(pattern string) (*streamingRegexps, error) {
+	// Anchor a lazy prefix and capture the earliest match of pattern. A
+	// continuation consumes the byte preceding the next search position so
+	// boundary assertions observe the same context as they do in one buffer.
+	initial, err := regexp.Compile(`\A(?s:.*?)((?:` + pattern + `))`)
+	if err != nil {
+		return nil, err
+	}
+	continuation, err := regexp.Compile(`\A(?s:.)(?s:.*?)((?:` + pattern + `))`)
+	if err != nil {
+		return nil, err
+	}
+	return &streamingRegexps{
+		initial:      initial,
+		continuation: continuation,
+	}, nil
+}
+
 func sanitizeMemory(buff []byte) {
 	for i := range buff {
 		if buff[i] < 32 || buff[i] >= 127 {
@@ -406,6 +429,89 @@ func searchLiteralPattern(
 
 			// regexp.FindAllIndex reports non-overlapping matches.
 			matched = 0
+		}
+	}
+
+	return results, nil
+}
+
+func searchPatternStream(
+	readerAt io.ReaderAt,
+	patterns *streamingRegexps,
+	reader *memoryRuneReader,
+	initialOffset, startAddr, entrySize uint64,
+	context int,
+) ([]PatternMatch, error) {
+	var results []PatternMatch
+	searchOffset := uint64(0)
+	previousMatchEnd := uint64(0)
+	havePreviousMatch := false
+	reader.setEntry(initialOffset, entrySize)
+
+	for {
+		readerOffset := searchOffset
+		regexPattern := patterns.initial
+		if searchOffset > 0 {
+			readerOffset--
+			regexPattern = patterns.continuation
+		}
+
+		reader.reset(readerOffset)
+		indexes := regexPattern.FindReaderSubmatchIndex(reader)
+		if reader.err != nil {
+			return nil, reader.err
+		}
+		if indexes == nil {
+			break
+		}
+		if len(indexes) < 4 || indexes[2] < 0 || indexes[3] < 0 {
+			return nil, errors.New("streaming regexp did not capture its match")
+		}
+
+		matchStart := readerOffset + uint64(indexes[2])
+		matchEnd := readerOffset + uint64(indexes[3])
+		if matchStart < searchOffset || matchEnd < matchStart || matchEnd > entrySize {
+			return nil, errors.New("streaming regexp returned an invalid match range")
+		}
+
+		acceptMatch := true
+		done := false
+		if matchEnd == searchOffset {
+			// Mirror regexp.FindAllIndex: ignore an empty match immediately
+			// after the previous match and advance by one input byte.
+			if havePreviousMatch && matchStart == previousMatchEnd {
+				acceptMatch = false
+			}
+			if searchOffset == entrySize {
+				done = true
+			} else {
+				searchOffset++
+			}
+		} else {
+			searchOffset = matchEnd
+		}
+		previousMatchEnd = matchEnd
+		havePreviousMatch = true
+
+		if acceptMatch {
+			match, err := readPatternMatch(
+				readerAt,
+				initialOffset,
+				startAddr,
+				entrySize,
+				matchStart,
+				matchEnd,
+				context,
+				0,
+				nil,
+			)
+			if err != nil {
+				return nil, err
+			}
+			results = append(results, match)
+		}
+		if done {
+			break
 		}
 	}
 

--- a/crit/mempages.go
+++ b/crit/mempages.go
@@ -226,6 +226,57 @@ func readMemoryAt(reader io.ReaderAt, buff []byte, initialOffset, offset uint64)
 	return err
 }
 
+type memoryRuneReader struct {
+	reader        io.ReaderAt
+	initialOffset uint64
+	entrySize     uint64
+	position      uint64
+	buffer        []byte
+	bufferStart   uint64
+	bufferEnd     uint64
+	err           error
+}
+
+func newMemoryRuneReader(reader io.ReaderAt, chunkSize int) *memoryRuneReader {
+	return &memoryRuneReader{
+		reader: reader,
+		buffer: make([]byte, chunkSize),
+	}
+}
+
+func (r *memoryRuneReader) setEntry(initialOffset, entrySize uint64) {
+	r.initialOffset = initialOffset
+	r.entrySize = entrySize
+	r.bufferStart = 0
+	r.bufferEnd = 0
+}
+
+func (r *memoryRuneReader) reset(position uint64) {
+	r.position = position
+	r.err = nil
+}
+
+func (r *memoryRuneReader) ReadRune() (rune, int, error) {
+	if r.position >= r.entrySize {
+		return 0, 0, io.EOF
+	}
+	if r.position < r.bufferStart || r.position >= r.bufferEnd {
+		readSize := min(uint64(len(r.buffer)), r.entrySize-r.position)
+		if err := readMemoryAt(r.reader, r.buffer[:int(readSize)], r.initialOffset, r.position); err != nil {
+			r.err = err
+			return 0, 0, err
+		}
+		r.bufferStart = r.position
+		r.bufferEnd = r.position + readSize
+	}
+	b := r.buffer[r.position-r.bufferStart]
+	r.position++
+	if b < 32 || b >= 127 {
+		b = '?'
+	}
+	return rune(b), 1, nil
+}
+
 func sanitizeMemory(buff []byte) {
 	for i := range buff {
 		if buff[i] < 32 || buff[i] >= 127 {

--- a/crit/mempages.go
+++ b/crit/mempages.go
@@ -277,6 +277,90 @@ func readPatternMatch(
 	}, nil
 }
 
+func literalFailureTable(pattern string) []int {
+	table := make([]int, len(pattern))
+	matched := 0
+	for i := 1; i < len(pattern); i++ {
+		for matched > 0 && pattern[i] != pattern[matched] {
+			matched = table[matched-1]
+		}
+		if pattern[i] == pattern[matched] {
+			matched++
+		}
+		table[i] = matched
+	}
+	return table
+}
+
+func searchLiteralPattern(
+	reader io.ReaderAt,
+	literalPattern string,
+	patternTable []int,
+	initialOffset, startAddr, entrySize uint64,
+	context, chunkSize int,
+) ([]PatternMatch, error) {
+	if len(literalPattern) == 0 {
+		return nil, errors.New("literal pattern cannot be empty")
+	}
+	canMatch := uint64(len(literalPattern)) <= entrySize
+	if canMatch && len(patternTable) != len(literalPattern) {
+		return nil, errors.New("literal pattern table has an invalid size")
+	}
+
+	var results []PatternMatch
+	bufferSize := min(uint64(chunkSize), entrySize)
+	buff := make([]byte, int(bufferSize))
+	matched := 0
+
+	for offset := uint64(0); offset < entrySize; offset += uint64(chunkSize) {
+		readSize := int(min(uint64(chunkSize), entrySize-offset))
+		window := buff[:readSize]
+		if err := readMemoryAt(reader, window, initialOffset, offset); err != nil {
+			return nil, err
+		}
+		if !canMatch {
+			continue
+		}
+		sanitizeMemory(window)
+
+		for i, b := range window {
+			for matched > 0 && b != literalPattern[matched] {
+				matched = patternTable[matched-1]
+			}
+			if b == literalPattern[matched] {
+				matched++
+			}
+			if matched != len(literalPattern) {
+				continue
+			}
+
+			matchEnd := offset + uint64(i) + 1
+			matchStart := matchEnd - uint64(len(literalPattern))
+
+			match, err := readPatternMatch(
+				reader,
+				initialOffset,
+				startAddr,
+				entrySize,
+				matchStart,
+				matchEnd,
+				context,
+				offset,
+				window,
+			)
+			if err != nil {
+				return nil, err
+			}
+			results = append(results, match)
+
+			// regexp.FindAllIndex reports non-overlapping matches.
+			matched = 0
+		}
+	}
+
+	return results, nil
+}
+
 // SearchPattern searches for a pattern in the process memory pages.
 func (mr *MemoryReader) SearchPattern(pattern string, escapeRegExpCharacters bool, context, chunkSize int) ([]PatternMatch, error) {
 	if context < 0 {
@@ -297,6 +381,8 @@ func (mr *MemoryReader) SearchPattern(pattern string, escapeRegExpCharacters boo
 	if err != nil {
 		return nil, err
 	}
+	literalPattern, literalOnly := regexPattern.LiteralPrefix()
+	var patternTable []int
 
 	var results []PatternMatch
 
@@ -319,6 +405,26 @@ func (mr *MemoryReader) SearchPattern(pattern string, escapeRegExpCharacters boo
 			initialOffset += e.GetNrPages() * uint64(mr.pageSize)
 		}
 
+		if literalOnly && len(literalPattern) > 0 {
+			if patternTable == nil && uint64(len(literalPattern)) <= entrySize {
+				patternTable = literalFailureTable(literalPattern)
+			}
+			matches, err := searchLiteralPattern(
+				f,
+				literalPattern,
+				patternTable,
+				initialOffset,
+				startAddr,
+				entrySize,
+				context,
+				chunkSize,
+			)
+			if err != nil {
+				return nil, err
+			}
+			results = append(results, matches...)
+			continue
+		}
 		for offset := uint64(0); offset < entrySize; offset += uint64(chunkSize) {
 			readSize := chunkSize
 			if entrySize-offset < uint64(chunkSize) {

--- a/crit/mempages.go
+++ b/crit/mempages.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -204,6 +205,78 @@ type PatternMatch struct {
 	Match   string
 }
 
+func readMemoryAt(reader io.ReaderAt, buff []byte, initialOffset, offset uint64) error {
+	if len(buff) == 0 {
+		return nil
+	}
+	if initialOffset > uint64(math.MaxInt64) || offset > uint64(math.MaxInt64)-initialOffset {
+		return fmt.Errorf("memory image offset is too large: %d + %d", initialOffset, offset)
+	}
+
+	n, err := reader.ReadAt(buff, int64(initialOffset+offset))
+	if n == len(buff) {
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		return err
+	}
+	if err == nil || errors.Is(err, io.EOF) {
+		return io.ErrUnexpectedEOF
+	}
+	return err
+}
+
+func sanitizeMemory(buff []byte) {
+	for i := range buff {
+		if buff[i] < 32 || buff[i] >= 127 {
+			buff[i] = '?'
+		}
+	}
+}
+
+func readPatternMatch(
+	reader io.ReaderAt,
+	initialOffset, startAddr, entrySize, matchStart, matchEnd uint64,
+	context int,
+	cachedStart uint64,
+	cached []byte,
+) (PatternMatch, error) {
+	contextSize := uint64(context)
+	contextStart := uint64(0)
+	if contextSize < matchStart {
+		contextStart = matchStart - contextSize
+	}
+
+	contextEnd := entrySize
+	if contextSize < entrySize-matchEnd {
+		contextEnd = matchEnd + contextSize
+	}
+
+	readSize := contextEnd - contextStart
+	if readSize > uint64(math.MaxInt) {
+		return PatternMatch{}, fmt.Errorf("memory match is too large: %d bytes", readSize)
+	}
+
+	var buff []byte
+	cachedEnd := cachedStart + uint64(len(cached))
+	if contextStart >= cachedStart && contextEnd <= cachedEnd {
+		buff = cached[contextStart-cachedStart : contextEnd-cachedStart]
+	} else {
+		buff = make([]byte, int(readSize))
+		if err := readMemoryAt(reader, buff, initialOffset, contextStart); err != nil {
+			return PatternMatch{}, err
+		}
+		sanitizeMemory(buff)
+	}
+
+	return PatternMatch{
+		Vaddr:   startAddr + matchStart,
+		Length:  int(matchEnd - matchStart),
+		Context: context,
+		Match:   string(buff),
+	}, nil
+}
+
 // SearchPattern searches for a pattern in the process memory pages.
 func (mr *MemoryReader) SearchPattern(pattern string, escapeRegExpCharacters bool, context, chunkSize int) ([]PatternMatch, error) {
 	if context < 0 {
@@ -236,6 +309,7 @@ func (mr *MemoryReader) SearchPattern(pattern string, escapeRegExpCharacters boo
 	for _, entry := range mr.pagemapEntries {
 		startAddr := entry.GetVaddr()
 		endAddr := startAddr + entry.GetNrPages()*uint64(mr.pageSize)
+		entrySize := endAddr - startAddr
 
 		initialOffset := uint64(0)
 		for _, e := range mr.pagemapEntries {
@@ -245,41 +319,41 @@ func (mr *MemoryReader) SearchPattern(pattern string, escapeRegExpCharacters boo
 			initialOffset += e.GetNrPages() * uint64(mr.pageSize)
 		}
 
-		for offset := uint64(0); offset < endAddr-startAddr; offset += uint64(chunkSize) {
+		for offset := uint64(0); offset < entrySize; offset += uint64(chunkSize) {
 			readSize := chunkSize
-			if endAddr-startAddr-offset < uint64(chunkSize) {
-				readSize = int(endAddr - startAddr - offset)
+			if entrySize-offset < uint64(chunkSize) {
+				readSize = int(entrySize - offset)
 			}
 
 			buff := make([]byte, readSize)
-			if _, err := f.ReadAt(buff, int64(initialOffset+offset)); err != nil {
-				if err == io.EOF {
-					break
-				}
+			if err := readMemoryAt(f, buff, initialOffset, offset); err != nil {
 				return nil, err
 			}
 
 			// Replace non-printable ASCII characters in the buffer with a question mark (0x3f) to prevent unexpected behavior
 			// during regex matching. Non-printable characters might cause incorrect interpretation or premature
 			// termination of strings, leading to inaccuracies in pattern matching.
-			for i := range buff {
-				if buff[i] < 32 || buff[i] >= 127 {
-					buff[i] = 0x3F
-				}
-			}
+			sanitizeMemory(buff)
 
 			indexes := regexPattern.FindAllIndex(buff, -1)
 			for _, index := range indexes {
-				startContext := max(index[0]-context, 0)
-
-				endContext := min(index[1]+context, len(buff))
-
-				results = append(results, PatternMatch{
-					Vaddr:   startAddr + offset + uint64(index[0]),
-					Length:  index[1] - index[0],
-					Context: context,
-					Match:   string(buff[startContext:endContext]),
-				})
+				matchStart := offset + uint64(index[0])
+				matchEnd := offset + uint64(index[1])
+				match, err := readPatternMatch(
+					f,
+					initialOffset,
+					startAddr,
+					entrySize,
+					matchStart,
+					matchEnd,
+					context,
+					offset,
+					buff,
+				)
+				if err != nil {
+					return nil, err
+				}
+				results = append(results, match)
 			}
 		}
 	}

--- a/crit/mempages_test.go
+++ b/crit/mempages_test.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
+	"slices"
 	"strings"
 	"testing"
 
@@ -748,6 +750,259 @@ func TestMemoryRuneReader(t *testing.T) {
 					t.Fatalf("got error %v, want %v", err, tc.wantErr)
 				}
 			})
+		}
+	})
+}
+
+func TestSearchPatternStream(t *testing.T) {
+	const startAddr = 0x1000
+	testCases := []struct {
+		name       string
+		memory     string
+		pattern    string
+		chunkSize  int
+		context    int
+		truncateAt int
+		wantError  error
+	}{
+		{name: "bounded", memory: "xxxxxxneedlexx", pattern: `n[e]{2}dle`, chunkSize: 8, truncateAt: -1},
+		{
+			name:       "unbounded",
+			memory:     "xxxxxxbegin" + strings.Repeat("x", 20) + "endxx",
+			pattern:    `begin.*end`,
+			chunkSize:  8,
+			context:    2,
+			truncateAt: -1,
+		},
+		{name: "multiple", memory: "begin1endxxbegin2end", pattern: `begin.*?end`, chunkSize: 4, truncateAt: -1},
+		{name: "alternation", memory: "xxabax", pattern: `(?:ab|a)`, chunkSize: 2, truncateAt: -1},
+		{name: "assertion", memory: "xxxxxx needle xx", pattern: `\bneedle\b`, chunkSize: 8, truncateAt: -1},
+		{name: "empty", memory: "axxxxxxx", pattern: `a?`, chunkSize: 1, truncateAt: -1},
+		{name: "sanitized", memory: "xxa\x00bxx", pattern: `a[?]b`, chunkSize: 2, truncateAt: -1},
+		{
+			name:       "truncated",
+			memory:     "xxxxxxxx",
+			pattern:    `missing.*pattern`,
+			chunkSize:  8,
+			truncateAt: 8,
+			wantError:  io.ErrUnexpectedEOF,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mr := newSearchPatternMemoryReader(t, tc.memory, tc.truncateAt)
+			memory := tc.memory + strings.Repeat("x", searchPatternTestPageSize-len(tc.memory))
+			file, err := os.Open(filepath.Join(mr.checkpointDir, "pages-1.img"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() { _ = file.Close() }()
+			patterns, err := compileStreamingRegexps(tc.pattern)
+			if err != nil {
+				t.Fatal(err)
+			}
+			reader := newMemoryRuneReader(file, tc.chunkSize)
+			matches, err := searchPatternStream(file, patterns, reader, 0, startAddr, searchPatternTestPageSize, tc.context)
+			if tc.wantError != nil {
+				if !errors.Is(err, tc.wantError) {
+					t.Fatalf("got error %v, want %v", err, tc.wantError)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			transformed := []byte(memory)
+			for i := range transformed {
+				if transformed[i] < 32 || transformed[i] >= 127 {
+					transformed[i] = '?'
+				}
+			}
+			want := regexp.MustCompile(tc.pattern).FindAllIndex(transformed, -1)
+			if len(matches) != len(want) {
+				t.Fatalf("got %d matches, want %d", len(matches), len(want))
+			}
+			for i, index := range want {
+				contextStart := max(index[0]-tc.context, 0)
+				contextEnd := min(index[1]+tc.context, len(transformed))
+				if matches[i].Vaddr != startAddr+uint64(index[0]) {
+					t.Errorf("match %d address = %#x, want %#x", i, matches[i].Vaddr, startAddr+uint64(index[0]))
+				}
+				if matches[i].Length != index[1]-index[0] {
+					t.Errorf("match %d length = %d, want %d", i, matches[i].Length, index[1]-index[0])
+				}
+				if matches[i].Match != string(transformed[contextStart:contextEnd]) {
+					t.Errorf("match %d = %q, want %q", i, matches[i].Match, transformed[contextStart:contextEnd])
+				}
+			}
+		})
+	}
+}
+
+func runSearchPatternStream(memory []byte, pattern string, chunkSize, context int) ([]PatternMatch, error) {
+	const (
+		initialOffset = 3
+		startAddr     = 0x2000
+	)
+	backing := make([]byte, initialOffset+len(memory))
+	copy(backing, "pad")
+	copy(backing[initialOffset:], memory)
+	readerAt := bytes.NewReader(backing)
+	patterns, err := compileStreamingRegexps(pattern)
+	if err != nil {
+		return nil, err
+	}
+	reader := newMemoryRuneReader(readerAt, chunkSize)
+	return searchPatternStream(
+		readerAt,
+		patterns,
+		reader,
+		initialOffset,
+		startAddr,
+		uint64(len(memory)),
+		context,
+	)
+}
+
+func expectedSearchPatternMatches(memory []byte, pattern string, context int) []PatternMatch {
+	const startAddr = 0x2000
+	transformed := append([]byte(nil), memory...)
+	for i := range transformed {
+		if transformed[i] < 32 || transformed[i] >= 127 {
+			transformed[i] = '?'
+		}
+	}
+
+	indexes := regexp.MustCompile(pattern).FindAllIndex(transformed, -1)
+	matches := make([]PatternMatch, 0, len(indexes))
+	for _, index := range indexes {
+		contextStart := max(index[0]-context, 0)
+		contextEnd := min(index[1]+context, len(transformed))
+		matches = append(matches, PatternMatch{
+			Vaddr:   startAddr + uint64(index[0]),
+			Length:  index[1] - index[0],
+			Context: context,
+			Match:   string(transformed[contextStart:contextEnd]),
+		})
+	}
+	return matches
+}
+
+func searchPatternStreamChunkSizes(memoryLength int, matches []PatternMatch) []int {
+	candidates := []int{1, 2, memoryLength + 1}
+	for _, match := range matches {
+		if match.Length > 1 {
+			candidates = append(candidates, match.Length-1)
+		}
+		if match.Length > 0 {
+			candidates = append(candidates, match.Length, match.Length+1)
+		}
+	}
+
+	seen := make(map[int]struct{}, len(candidates))
+	chunkSizes := make([]int, 0, len(candidates))
+	for _, chunkSize := range candidates {
+		if chunkSize <= 0 {
+			continue
+		}
+		if _, ok := seen[chunkSize]; ok {
+			continue
+		}
+		seen[chunkSize] = struct{}{}
+		chunkSizes = append(chunkSizes, chunkSize)
+	}
+	return chunkSizes
+}
+
+func TestSearchPatternStreamDifferential(t *testing.T) {
+	testCases := []struct {
+		name    string
+		memory  []byte
+		pattern string
+		context int
+	}{
+		{name: "start anchor", memory: []byte("abc"), pattern: `^a`, context: 1},
+		{name: "end anchor", memory: []byte("abc"), pattern: `c$`, context: 1},
+		{name: "absolute start", memory: []byte("abc"), pattern: `\Aa`},
+		{name: "absolute end", memory: []byte("abc"), pattern: `c\z`},
+		{name: "continuation start anchor", memory: []byte("ab"), pattern: `a|^b`},
+		{name: "continuation absolute start", memory: []byte("ab"), pattern: `a|\Ab`},
+		{name: "continuation word boundary", memory: []byte("ab"), pattern: `a|\bb`},
+		{name: "continuation non-word boundary", memory: []byte("ab"), pattern: `a|\Bb`},
+		{name: "continuation end anchor", memory: []byte("ab"), pattern: `a|b$`},
+		{name: "continuation absolute end", memory: []byte("ab"), pattern: `a|b\z`},
+		{name: "word boundaries", memory: []byte(" a "), pattern: `\ba\b`},
+		{name: "shared prefix long first", memory: []byte("ab"), pattern: `(?:ab|a)`},
+		{name: "shared prefix short first", memory: []byte("ab"), pattern: `(?:a|ab)`},
+		{name: "greedy", memory: []byte("a1b2b"), pattern: `a.*b`},
+		{name: "non-greedy", memory: []byte("a1b2b"), pattern: `a.*?b`},
+		{name: "captures", memory: []byte("xxabbx"), pattern: `(a(b)?)`, context: 1},
+		{name: "named capture", memory: []byte("xxaaax"), pattern: `(?P<word>a+)`},
+		{name: "inline flags", memory: []byte("xxAaax"), pattern: `(?i:a+)`},
+		{name: "empty repetition", memory: []byte("baa"), pattern: `a*`},
+		{name: "empty expression", memory: []byte("ab"), pattern: `(?:)`},
+		{name: "empty record", pattern: `(?:)`},
+		{name: "empty record start", pattern: `^`},
+		{name: "empty record end", pattern: `$`},
+		{name: "no match", memory: []byte("abc"), pattern: `z+`},
+		{name: "sanitized NUL", memory: []byte{'a', 0, 'b'}, pattern: `a[?]b`, context: 2},
+		{name: "sanitized invalid UTF-8", memory: []byte{0xff, 'a'}, pattern: `[?]a`},
+		{name: "sanitized non-ASCII", memory: []byte("é"), pattern: `[?]+`},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			want := expectedSearchPatternMatches(tc.memory, tc.pattern, tc.context)
+			for _, chunkSize := range searchPatternStreamChunkSizes(len(tc.memory), want) {
+				t.Run(fmt.Sprintf("chunk_%d", chunkSize), func(t *testing.T) {
+					got, err := runSearchPatternStream(tc.memory, tc.pattern, chunkSize, tc.context)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if !slices.Equal(got, want) {
+						t.Fatalf("memory %q pattern %q: got %#v, want %#v", tc.memory, tc.pattern, got, want)
+					}
+				})
+			}
+		})
+	}
+}
+
+func FuzzSearchPatternStream(f *testing.F) {
+	patterns := []string{
+		`a+`, `a*`, `(?:)`, `^`, `$`, `\Aa`, `a\z`, `\ba\b`, `\B`,
+		`a.*b`, `a.*?b`, `(?:ab|a)`, `(?:a|ab)`, `(a(b)?)`,
+		`(?P<word>a+)`, `(?i:a+)`, `[?]{1,4}`,
+	}
+	for i := range patterns {
+		f.Add([]byte("ab\x00é"), uint8(i), uint8(i+1), uint8(i))
+	}
+
+	f.Fuzz(func(t *testing.T, memory []byte, patternIndex, chunkSeed, contextSeed uint8) {
+		if len(memory) > 256 {
+			memory = memory[:256]
+		}
+		pattern := patterns[int(patternIndex)%len(patterns)]
+		chunkSize := int(chunkSeed%32) + 1
+		context := int(contextSeed % 33)
+
+		got, err := runSearchPatternStream(memory, pattern, chunkSize, context)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := expectedSearchPatternMatches(memory, pattern, context)
+		if !slices.Equal(got, want) {
+			t.Fatalf(
+				"memory %q pattern %q chunk %d context %d: got %#v, want %#v",
+				memory,
+				pattern,
+				chunkSize,
+				context,
+				got,
+				want,
+			)
 		}
 	})
 }

--- a/crit/mempages_test.go
+++ b/crit/mempages_test.go
@@ -2,17 +2,27 @@ package crit
 
 import (
 	"errors"
+	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/checkpoint-restore/go-criu/v8/crit/images/pagemap"
 	"github.com/checkpoint-restore/go-criu/v8/crit/images/pstree"
 )
 
 const (
-	testImgsDir = "test-imgs"
+	testImgsDir               = "test-imgs"
+	searchPatternTestPageSize = 64
 )
+
+type readerAtFunc func([]byte, int64) (int, error)
+
+func (f readerAtFunc) ReadAt(buff []byte, offset int64) (int, error) {
+	return f(buff, offset)
+}
 
 func TestNewMemoryReader(t *testing.T) {
 	pid, err := getTestImgPID()
@@ -343,6 +353,112 @@ func TestSearchPattern(t *testing.T) {
 				if !strings.Contains(match.Match, content.String()) {
 					t.Errorf("Expected to find %s in matched pattern %s", content.String(), match.Match)
 				}
+			}
+		})
+	}
+}
+
+func newSearchPatternMemoryReader(t *testing.T, memory string, truncateAt int) *MemoryReader {
+	t.Helper()
+	if len(memory) > searchPatternTestPageSize {
+		t.Fatalf("memory has %d bytes, page size is %d", len(memory), searchPatternTestPageSize)
+	}
+	memory += strings.Repeat("x", searchPatternTestPageSize-len(memory))
+	fileMemory := memory
+	if truncateAt >= 0 {
+		fileMemory = memory[:truncateAt]
+	}
+
+	const pagesID = 1
+	checkpointDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(checkpointDir, "pages-1.img"), []byte(fileMemory), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	vaddr := uint64(0x1000)
+	compatNrPages := uint32(1)
+	nrPages := uint64(1)
+
+	return &MemoryReader{
+		checkpointDir: checkpointDir,
+		pagesID:       pagesID,
+		pageSize:      searchPatternTestPageSize,
+		pagemapEntries: []*pagemap.PagemapEntry{
+			{
+				Vaddr:         &vaddr,
+				CompatNrPages: &compatNrPages,
+				NrPages:       &nrPages,
+			},
+		},
+	}
+}
+
+func TestSearchPatternContextAcrossChunkBoundary(t *testing.T) {
+	const (
+		chunkSize = 8
+		startAddr = 0x1000
+	)
+	testCases := []struct {
+		name       string
+		memory     string
+		wantOffset uint64
+	}{
+		{name: "match starts at boundary", memory: "xxxxxxxxneedlexx", wantOffset: 8},
+		{name: "match ends at boundary", memory: "xxneedlexxxxxxxx", wantOffset: 2},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mr := newSearchPatternMemoryReader(t, tc.memory, -1)
+			matches, err := mr.SearchPattern("needle", true, 2, chunkSize)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(matches) != 1 {
+				t.Fatalf("got %d matches, want 1", len(matches))
+			}
+			if matches[0].Vaddr != startAddr+tc.wantOffset {
+				t.Errorf("address = %#x, want %#x", matches[0].Vaddr, startAddr+tc.wantOffset)
+			}
+			if matches[0].Length != len("needle") {
+				t.Errorf("length = %d, want %d", matches[0].Length, len("needle"))
+			}
+			if matches[0].Match != "xxneedlexx" {
+				t.Errorf("match = %q, want %q", matches[0].Match, "xxneedlexx")
+			}
+		})
+	}
+}
+
+func TestSearchPatternTruncatedContext(t *testing.T) {
+	mr := newSearchPatternMemoryReader(t, "xxxxxxxx", 8)
+	_, err := mr.SearchPattern("x", true, 8, 8)
+	if !errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Fatalf("got error %v, want %v", err, io.ErrUnexpectedEOF)
+	}
+}
+
+func TestReadPatternMatchErrors(t *testing.T) {
+	readErr := errors.New("read failed")
+	testCases := []struct {
+		name      string
+		readerErr error
+		wantErr   error
+	}{
+		{name: "EOF", readerErr: io.EOF, wantErr: io.ErrUnexpectedEOF},
+		{name: "wrapped EOF", readerErr: fmt.Errorf("wrapped: %w", io.EOF), wantErr: io.ErrUnexpectedEOF},
+		{name: "short read", wantErr: io.ErrUnexpectedEOF},
+		{name: "other error", readerErr: readErr, wantErr: readErr},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			reader := readerAtFunc(func(buff []byte, _ int64) (int, error) {
+				buff[0] = 'x'
+				return 1, tc.readerErr
+			})
+			_, err := readPatternMatch(reader, 0, 0x1000, 4, 1, 2, 2, 0, nil)
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("got error %v, want %v", err, tc.wantErr)
 			}
 		})
 	}

--- a/crit/mempages_test.go
+++ b/crit/mempages_test.go
@@ -416,6 +416,57 @@ func newSearchPatternMemoryReader(t *testing.T, memory string, truncateAt int) *
 	}
 }
 
+type searchPatternMemoryEntry struct {
+	vaddr  uint64
+	memory string
+}
+
+func newSearchPatternMultiEntryMemoryReader(
+	t *testing.T,
+	entries []searchPatternMemoryEntry,
+	truncateAt int,
+) *MemoryReader {
+	t.Helper()
+	const (
+		pageSize = 8
+		pagesID  = 1
+	)
+
+	var payload []byte
+	pagemapEntries := make([]*pagemap.PagemapEntry, 0, len(entries))
+	for i, entry := range entries {
+		if len(entry.memory)%pageSize != 0 {
+			t.Fatalf("entry %d has %d bytes, want a multiple of %d", i, len(entry.memory), pageSize)
+		}
+		payload = append(payload, entry.memory...)
+		vaddr := entry.vaddr
+		nrPages := uint64(len(entry.memory) / pageSize)
+		compatNrPages := uint32(nrPages)
+		pagemapEntries = append(pagemapEntries, &pagemap.PagemapEntry{
+			Vaddr:         &vaddr,
+			CompatNrPages: &compatNrPages,
+			NrPages:       &nrPages,
+		})
+	}
+	if truncateAt >= 0 {
+		if truncateAt > len(payload) {
+			t.Fatalf("truncate offset %d exceeds payload size %d", truncateAt, len(payload))
+		}
+		payload = payload[:truncateAt]
+	}
+
+	checkpointDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(checkpointDir, "pages-1.img"), payload, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return &MemoryReader{
+		checkpointDir:  checkpointDir,
+		pagesID:        pagesID,
+		pageSize:       pageSize,
+		pagemapEntries: pagemapEntries,
+	}
+}
+
 func TestSearchPatternContextAcrossChunkBoundary(t *testing.T) {
 	const (
 		chunkSize = 8
@@ -1003,6 +1054,187 @@ func FuzzSearchPatternStream(f *testing.F) {
 				got,
 				want,
 			)
+		}
+	})
+}
+
+func TestSearchRegexpAcrossChunkBoundary(t *testing.T) {
+	const startAddr = 0x1000
+
+	t.Run("returns cross-boundary match with context", func(t *testing.T) {
+		memory := "xxxxxxbegin" + strings.Repeat("x", 20) + "endxx"
+		mr := newSearchPatternMemoryReader(t, memory, -1)
+		matches, err := mr.SearchPattern(`begin.*end`, false, 2, 8)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(matches) != 1 {
+			t.Fatalf("got %d matches, want 1", len(matches))
+		}
+		wantLength := len("begin") + 20 + len("end")
+		if matches[0].Vaddr != startAddr+6 {
+			t.Errorf("address = %#x, want %#x", matches[0].Vaddr, startAddr+6)
+		}
+		if matches[0].Length != wantLength {
+			t.Errorf("length = %d, want %d", matches[0].Length, wantLength)
+		}
+		wantMatch := "xxbegin" + strings.Repeat("x", 20) + "endxx"
+		if matches[0].Match != wantMatch {
+			t.Errorf("match = %q, want %q", matches[0].Match, wantMatch)
+		}
+	})
+
+	t.Run("propagates truncated input", func(t *testing.T) {
+		mr := newSearchPatternMemoryReader(t, "xxxxxxxx", 8)
+		_, err := mr.SearchPattern(`missing.*pattern`, false, 0, 8)
+		if !errors.Is(err, io.ErrUnexpectedEOF) {
+			t.Fatalf("got error %v, want %v", err, io.ErrUnexpectedEOF)
+		}
+	})
+}
+
+func TestSearchPatternMultipleEntries(t *testing.T) {
+	t.Run("maps later entry payload offsets", func(t *testing.T) {
+		entries := []searchPatternMemoryEntry{
+			{vaddr: 0x1000, memory: "abcdefghijklmnop"},
+			{vaddr: 0x5000, memory: "xneedlex"},
+		}
+		for _, tc := range []struct {
+			name    string
+			pattern string
+			escape  bool
+		}{
+			{name: "literal", pattern: "needle", escape: true},
+			{name: "regexp", pattern: `n(?:e|E)edle`},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				mr := newSearchPatternMultiEntryMemoryReader(t, entries, -1)
+				matches, err := mr.SearchPattern(tc.pattern, tc.escape, 0, 3)
+				if err != nil {
+					t.Fatal(err)
+				}
+				want := []PatternMatch{{Vaddr: 0x5001, Length: 6, Match: "needle"}}
+				if !slices.Equal(matches, want) {
+					t.Fatalf("got %#v, want %#v", matches, want)
+				}
+			})
+		}
+	})
+
+	t.Run("does not match across entries", func(t *testing.T) {
+		entries := []searchPatternMemoryEntry{
+			{vaddr: 0x1000, memory: "xxxxxabc"},
+			{vaddr: 0x5000, memory: "defxxxxx"},
+		}
+		for _, tc := range []struct {
+			name    string
+			pattern string
+			escape  bool
+		}{
+			{name: "literal", pattern: "abcdef", escape: true},
+			{name: "regexp", pattern: `abc(?:d|D)ef`},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				mr := newSearchPatternMultiEntryMemoryReader(t, entries, -1)
+				matches, err := mr.SearchPattern(tc.pattern, tc.escape, 0, 3)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if len(matches) != 0 {
+					t.Fatalf("got %#v, want no matches", matches)
+				}
+			})
+		}
+	})
+
+	t.Run("clips context at entry boundaries", func(t *testing.T) {
+		entries := []searchPatternMemoryEntry{
+			{vaddr: 0x1000, memory: "xxxxxabc"},
+			{vaddr: 0x5000, memory: "defxxxxx"},
+		}
+		for _, tc := range []struct {
+			name    string
+			pattern string
+			escape  bool
+			want    PatternMatch
+		}{
+			{
+				name:    "literal suffix",
+				pattern: "abc",
+				escape:  true,
+				want:    PatternMatch{Vaddr: 0x1005, Length: 3, Context: 16, Match: "xxxxxabc"},
+			},
+			{
+				name:    "regexp prefix",
+				pattern: `d(?:e|E)f`,
+				want:    PatternMatch{Vaddr: 0x5000, Length: 3, Context: 16, Match: "defxxxxx"},
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				mr := newSearchPatternMultiEntryMemoryReader(t, entries, -1)
+				matches, err := mr.SearchPattern(tc.pattern, tc.escape, 16, 3)
+				if err != nil {
+					t.Fatal(err)
+				}
+				want := []PatternMatch{tc.want}
+				if !slices.Equal(matches, want) {
+					t.Fatalf("got %#v, want %#v", matches, want)
+				}
+			})
+		}
+	})
+
+	t.Run("resets anchors at entry boundaries", func(t *testing.T) {
+		entries := []searchPatternMemoryEntry{
+			{vaddr: 0x1000, memory: "axxxxxxx"},
+			{vaddr: 0x5000, memory: "ayyyyyyy"},
+		}
+		mr := newSearchPatternMultiEntryMemoryReader(t, entries, -1)
+		matches, err := mr.SearchPattern(`^a`, false, 0, 3)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := []PatternMatch{
+			{Vaddr: 0x1000, Length: 1, Match: "a"},
+			{Vaddr: 0x5000, Length: 1, Match: "a"},
+		}
+		if !slices.Equal(matches, want) {
+			t.Fatalf("got %#v, want %#v", matches, want)
+		}
+	})
+
+	t.Run("reports later entry truncation", func(t *testing.T) {
+		entries := []searchPatternMemoryEntry{
+			{vaddr: 0x1000, memory: "abcdefgh"},
+			{vaddr: 0x5000, memory: "ijklmnop"},
+		}
+		for _, tc := range []struct {
+			name    string
+			pattern string
+			escape  bool
+		}{
+			{name: "literal", pattern: "z", escape: true},
+			{name: "regexp", pattern: `z+`},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				mr := newSearchPatternMultiEntryMemoryReader(t, entries, 12)
+				_, err := mr.SearchPattern(tc.pattern, tc.escape, 0, 3)
+				if !errors.Is(err, io.ErrUnexpectedEOF) {
+					t.Fatalf("got error %v, want %v", err, io.ErrUnexpectedEOF)
+				}
+			})
+		}
+	})
+
+	t.Run("reports truncated later entry context", func(t *testing.T) {
+		entries := []searchPatternMemoryEntry{
+			{vaddr: 0x1000, memory: "abcdefgh"},
+			{vaddr: 0x5000, memory: "needlezz"},
+		}
+		mr := newSearchPatternMultiEntryMemoryReader(t, entries, 14)
+		_, err := mr.SearchPattern("needle", true, 2, 6)
+		if !errors.Is(err, io.ErrUnexpectedEOF) {
+			t.Fatalf("got error %v, want %v", err, io.ErrUnexpectedEOF)
 		}
 	})
 }

--- a/crit/mempages_test.go
+++ b/crit/mempages_test.go
@@ -658,6 +658,100 @@ func BenchmarkSearchLiteralPattern(b *testing.B) {
 	}
 }
 
+func TestMemoryRuneReader(t *testing.T) {
+	t.Run("buffers and sanitizes bytes", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "pages.img")
+		if err := os.WriteFile(path, []byte{'s', 'k', 'i', 'p', 'a', 'b', 0, 0xff}, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		file, err := os.Open(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() { _ = file.Close() }()
+
+		reader := newMemoryRuneReader(file, 2)
+		reader.setEntry(4, 4)
+		var got []rune
+		for {
+			r, size, err := reader.ReadRune()
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if size != 1 {
+				t.Fatalf("rune size = %d, want 1", size)
+			}
+			got = append(got, r)
+		}
+		if string(got) != "ab??" {
+			t.Fatalf("got %q, want %q", got, "ab??")
+		}
+
+		reader.reset(1)
+		r, size, err := reader.ReadRune()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if r != 'b' || size != 1 {
+			t.Fatalf("got (%q, %d), want (%q, 1)", r, size, 'b')
+		}
+	})
+
+	t.Run("rejects truncated entry", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "pages.img")
+		if err := os.WriteFile(path, []byte("abc"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		file, err := os.Open(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() { _ = file.Close() }()
+
+		reader := newMemoryRuneReader(file, 2)
+		reader.setEntry(0, 4)
+		if _, _, err := reader.ReadRune(); err != nil {
+			t.Fatal(err)
+		}
+		if _, _, err := reader.ReadRune(); err != nil {
+			t.Fatal(err)
+		}
+		if _, _, err := reader.ReadRune(); !errors.Is(err, io.ErrUnexpectedEOF) {
+			t.Fatalf("got error %v, want %v", err, io.ErrUnexpectedEOF)
+		}
+	})
+
+	t.Run("propagates read errors", func(t *testing.T) {
+		readErr := errors.New("read failed")
+		testCases := []struct {
+			name      string
+			readerErr error
+			wantErr   error
+		}{
+			{name: "EOF", readerErr: io.EOF, wantErr: io.ErrUnexpectedEOF},
+			{name: "wrapped EOF", readerErr: fmt.Errorf("wrapped: %w", io.EOF), wantErr: io.ErrUnexpectedEOF},
+			{name: "short read", wantErr: io.ErrUnexpectedEOF},
+			{name: "other error", readerErr: readErr, wantErr: readErr},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				reader := newMemoryRuneReader(readerAtFunc(func(buff []byte, _ int64) (int, error) {
+					buff[0] = 'x'
+					return 1, tc.readerErr
+				}), 2)
+				reader.setEntry(0, 2)
+				if _, _, err := reader.ReadRune(); !errors.Is(err, tc.wantErr) {
+					t.Fatalf("got error %v, want %v", err, tc.wantErr)
+				}
+			})
+		}
+	})
+}
+
 // helper function to get the PID from the test-imgs directory
 func getTestImgPID() (uint32, error) {
 	psTreeImg, err := getImg(filepath.Join(testImgsDir, "pstree.img"), &pstree.PstreeEntry{})

--- a/crit/mempages_test.go
+++ b/crit/mempages_test.go
@@ -1,6 +1,7 @@
 package crit
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -22,6 +23,27 @@ type readerAtFunc func([]byte, int64) (int, error)
 
 func (f readerAtFunc) ReadAt(buff []byte, offset int64) (int, error) {
 	return f(buff, offset)
+}
+
+type countingReaderAt struct {
+	data       []byte
+	bytesRead  int
+	readStarts []int64
+	readSizes  []int
+}
+
+func (r *countingReaderAt) ReadAt(buff []byte, offset int64) (int, error) {
+	r.readStarts = append(r.readStarts, offset)
+	r.readSizes = append(r.readSizes, len(buff))
+	if offset < 0 || offset >= int64(len(r.data)) {
+		return 0, io.EOF
+	}
+	n := copy(buff, r.data[offset:])
+	r.bytesRead += n
+	if n != len(buff) {
+		return n, io.EOF
+	}
+	return n, nil
 }
 
 func TestNewMemoryReader(t *testing.T) {
@@ -461,6 +483,178 @@ func TestReadPatternMatchErrors(t *testing.T) {
 				t.Fatalf("got error %v, want %v", err, tc.wantErr)
 			}
 		})
+	}
+}
+
+func TestSearchLiteralAcrossChunkBoundary(t *testing.T) {
+	const startAddr = 0x1000
+	testCases := []struct {
+		name        string
+		memory      string
+		pattern     string
+		chunkSize   int
+		context     int
+		wantOffsets []uint64
+		wantMatch   string
+	}{
+		{
+			name:        "crosses boundary",
+			memory:      "xxxxxxneedlexx",
+			pattern:     "needle",
+			chunkSize:   8,
+			context:     2,
+			wantOffsets: []uint64{6},
+			wantMatch:   "xxneedlexx",
+		},
+		{
+			name:        "longer than chunk",
+			memory:      "xxlongneedlexx",
+			pattern:     "longneedle",
+			chunkSize:   4,
+			wantOffsets: []uint64{2},
+			wantMatch:   "longneedle",
+		},
+		{
+			name:        "non-overlapping matches",
+			memory:      "aaaa",
+			pattern:     "aa",
+			chunkSize:   1,
+			wantOffsets: []uint64{0, 2},
+			wantMatch:   "aa",
+		},
+		{
+			name:        "sanitized boundary",
+			memory:      "xxxxxxa\x00bxx",
+			pattern:     "a?b",
+			chunkSize:   8,
+			wantOffsets: []uint64{6},
+			wantMatch:   "a?b",
+		},
+		{
+			name:        "prefix fallback across boundaries",
+			memory:      "xxabababacaxx",
+			pattern:     "ababaca",
+			chunkSize:   3,
+			wantOffsets: []uint64{4},
+			wantMatch:   "ababaca",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mr := newSearchPatternMemoryReader(t, tc.memory, -1)
+			matches, err := mr.SearchPattern(tc.pattern, true, tc.context, tc.chunkSize)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(matches) != len(tc.wantOffsets) {
+				t.Fatalf("got %d matches, want %d", len(matches), len(tc.wantOffsets))
+			}
+			for i, match := range matches {
+				if match.Vaddr != startAddr+tc.wantOffsets[i] {
+					t.Errorf("match %d address = %#x, want %#x", i, match.Vaddr, startAddr+tc.wantOffsets[i])
+				}
+				if match.Length != len(tc.pattern) {
+					t.Errorf("match %d length = %d, want %d", i, match.Length, len(tc.pattern))
+				}
+				if match.Match != tc.wantMatch {
+					t.Errorf("match %d = %q, want %q", i, match.Match, tc.wantMatch)
+				}
+			}
+		})
+	}
+}
+
+func TestSearchLiteralTruncatedInput(t *testing.T) {
+	testCases := []struct {
+		name    string
+		pattern string
+	}{
+		{name: "partial search window", pattern: "needle"},
+		{name: "at chunk boundary", pattern: "z"},
+		{name: "literal longer than entry", pattern: strings.Repeat("x", searchPatternTestPageSize+1)},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mr := newSearchPatternMemoryReader(t, "xxxxxxxx", 8)
+			_, err := mr.SearchPattern(tc.pattern, true, 0, 8)
+			if !errors.Is(err, io.ErrUnexpectedEOF) {
+				t.Fatalf("got error %v, want %v", err, io.ErrUnexpectedEOF)
+			}
+		})
+	}
+}
+
+func TestSearchLiteralReadsInputOnce(t *testing.T) {
+	const (
+		entrySize = 4096
+		chunkSize = 16
+	)
+	reader := &countingReaderAt{data: bytes.Repeat([]byte{'a'}, entrySize)}
+	literalPattern := strings.Repeat("a", 256) + "b"
+	patternTable := literalFailureTable(literalPattern)
+
+	matches, err := searchLiteralPattern(
+		reader,
+		literalPattern,
+		patternTable,
+		0,
+		0x1000,
+		entrySize,
+		0,
+		chunkSize,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("got %d matches, want 0", len(matches))
+	}
+	if reader.bytesRead != entrySize {
+		t.Fatalf("read %d bytes, want %d", reader.bytesRead, entrySize)
+	}
+	for i, offset := range reader.readStarts {
+		wantOffset := int64(i * chunkSize)
+		if offset != wantOffset {
+			t.Fatalf("read %d starts at %d, want %d", i, offset, wantOffset)
+		}
+		wantSize := min(chunkSize, entrySize-i*chunkSize)
+		if reader.readSizes[i] != wantSize {
+			t.Fatalf("read %d has size %d, want %d", i, reader.readSizes[i], wantSize)
+		}
+	}
+}
+
+func BenchmarkSearchLiteralPattern(b *testing.B) {
+	const (
+		entrySize = 1 << 20
+		chunkSize = 256
+	)
+	memory := bytes.Repeat([]byte{'a'}, entrySize)
+	literalPattern := strings.Repeat("a", 4096) + "b"
+	patternTable := literalFailureTable(literalPattern)
+	reader := bytes.NewReader(memory)
+	b.ReportAllocs()
+	b.SetBytes(entrySize)
+
+	for b.Loop() {
+		matches, err := searchLiteralPattern(
+			reader,
+			literalPattern,
+			patternTable,
+			0,
+			0x1000,
+			entrySize,
+			0,
+			chunkSize,
+		)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if len(matches) != 0 {
+			b.Fatalf("got %d matches, want 0", len(matches))
+		}
 	}
 }
 


### PR DESCRIPTION
`MemoryReader.SearchPattern` currently searches each memory chunk independently, which means patterns that span chunk boundaries are missed. This pull request aims to fix this by searching exact literals with overlapping chunks, while evaluating general regular expressions through a bounded streaming reader over the entire pagemap entry.