### PR TITLE
Add Manassé to maintainers

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,4 +1,5 @@
 Adrian Reber <areber@redhat.com>
+Kouame Behouba Manasse <behouba@gmail.com>
 Kir Kolyshkin <kolyshkin@gmail.com>
 Prajwal S N <prajwalnadig21@gmail.com>
 Radostin Stoyanov <rstoyanov@fedoraproject.org>


### PR DESCRIPTION
Manassé (@behouba) has made many significant contributions to go-criu and checkpointctl over the past few years. His help with maintaining these projects would be invaluable.